### PR TITLE
Add dude PA to Python projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If you are an open source project maintainer, add the label `first-timers-only` 
 - [mitmproxy](https://github.com/mitmproxy/mitmproxy/labels/good-first-contribution) _(label: good first contribution)_ <br> An interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers
 - [Mailpile](https://github.com/mailpile/Mailpile/labels/Low%20Hanging%20Fruit) _(label: low hanging fruit)_ <br> A free & open modern, fast email client with user-friendly encryption and privacy features
 - [coala](https://github.com/issues?utf8=✓&q=is%3Aopen+is%3Aissue+user%3Acoala+label%3Adifficulty%2Fnewcomer++no%3Aassignee) _(label: difficulty/newcomer)_ <br>A unified command-line interface for linting and fixing all your code, regardless of the programming languages you use.
+- [dude](https://github.com/dude-pa/dude/issues?q=is%3Aissue+is%3Aopen+label%3A%22difficulty%3A+easy%22) _(label: difficulty: easy)_ <br>Personal assistant based on the command line.
 
 ## Ruby
 


### PR DESCRIPTION
This PR adds [Dude PA](https://github.com/dude-pa/dude) to the list. [dude](https://github.com/dude-pa/dude) is a personal assistant based on the command line.
I have tried to document the project keeping in mind the beginners in open source.