### PR TITLE
Rename "beginner" to "good first issue"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are an open source project maintainer, add the label `first-timers-only` 
 
 - [TEAMMATES](https://github.com/TEAMMATES/teammates/labels/d.FirstTimers) _(label: d.FirstTimers)_ <br> TEAMMATES is a free online tool for managing peer evaluations and other feedback paths of your students.
 - [elasticsearch](https://github.com/elastic/elasticsearch/labels/low%20hanging%20fruit) _(label: low hanging fruit)_ <br> Open Source, Distributed, RESTful Search Engine.
-- [JabRef](https://github.com/JabRef/jabref/labels/beginner) _(label: beginner)_ <br> Desktop application moving from SWING to JavaFX. Focus on code quality: Usage of code quality tools such as [CodeCov](https://codecov.io/) and [Codacy](https://www.codacy.com/). Each Pull Request is reviewed by two developers to provide high-quality feedback and to ensure high quality of new contributions.
+- [JabRef](https://github.com/JabRef/jabref/labels/good%20first%20issue) _(label: good first issue)_ <br> Desktop application moving from SWING to JavaFX. Focus on code quality: Usage of code quality tools such as [CodeCov](https://codecov.io/) and [Codacy](https://www.codacy.com/). Each Pull Request is reviewed by two developers to provide high-quality feedback and to ensure high quality of new contributions.
 - [Wikimedia Commons Android App](https://github.com/commons-app/apps-android-commons/labels/beginner%20friendly) _(label: beginner friendly)_ <br> Allows users to upload pictures from their Android phone/tablet to Wikimedia Commons.
 
 ## JavaScript


### PR DESCRIPTION
I saw following popup on JabRef's GitHub repository:

![grafik](https://user-images.githubusercontent.com/1366654/31479535-2d2d1170-af18-11e7-9440-6af4b8765f7c.png)

Google did not find more about this movement, but I followed the suggestion by GitHub and renamed "beginner" to "good first issue". Thus, I also renamed it here.