### PR TITLE
Update label and link for Hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you are an open source project maintainer, add the label `first-timers-only` 
 - [FreeCodeCamp](https://github.com/FreeCodeCamp/FreeCodeCamp/labels/first-timers-only) _(label: first-timers-only)_ <br> Open source codebase and curriculum. Learn to code and help nonprofits.
 - [Ghost](https://github.com/TryGhost/Ghost/labels/beginner) _(label: beginner)_ <br> Just a blogging platform
 - [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn/labels/good%20for%20beginner) _(label: good for beginner)_ <br> Awesome ESLint rules.
-- [Hyper](https://github.com/zeit/hyper/labels/Good%20for%20beginners) _(label: Good for beginners)_ <br> JS/HTML/CSS Terminal
+- [Hyper](https://github.com/zeit/hyper/labels/good%20first%20issue) _(label: good first issue)_ <br> JS/HTML/CSS Terminal
 - [pdf.js](https://github.com/mozilla/pdf.js/labels/5-good-beginner-bug) _(label: 5-good-beginner-bug)_ <br> PDF Reader in JavaScript
 - [Moment.js](https://github.com/moment/moment/labels/Up-For-Grabs) _(label: Up-For-Grabs)_ <br> A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 - [serverless](https://github.com/serverless/serverless/labels/help-wanted-easy) _(label: help-wanted-easy)_ <br> The Serverless Framework


### PR DESCRIPTION
I was looking for things to work on and noticed that this link for Hyper didn't reflect the correct name of the label for beginners working on first issues.