### PR TITLE
Update VS code link

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you are an open source project maintainer, add the label `first-timers-only` 
 ## TypeScript
 
 - [TypeScript](https://github.com/Microsoft/TypeScript/labels/Effort%3A%20Easy) _(label: Effort: Easy)_ TypeScript is a superset of JavaScript that compiles to clean JavaScript output.
-- [Visual Studio Code](https://github.com/Microsoft/vscode/labels/beginner) _(label: beginner)_ a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
+- [Visual Studio Code](https://github.com/Microsoft/vscode/labels/good%20first%20issue) _(label: good first issue)_ a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
 
 ## Contribute
 


### PR DESCRIPTION
Label: good first issue and label:help wanted are now used instead on the vs code repository