### PR TITLE
Changed link for Leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are looking to contribute then explore this list, look at [`first-timers-
 - [annyang](https://github.com/TalAter/annyang/labels/first-timers-only) _(label: first-timers-only)_ <br> A popular Speech Recognition library used to communicate with everything from websites to smart mirrors to flying drones.
 - [Clementine.js Boilerplate](https://github.com/johnstonbl01/clementinejs/labels/beginner) _(label: beginner)_ <br> The elegant and lightweight full stack JavaScript boilerplate.
 - [PouchDB](https://github.com/pouchdb/pouchdb/labels/first%20timers%20only) _(label: first time only)_ <br> PouchDB is a pocket-sized database.
-- [Leaflet](https://github.com/Leaflet/Leaflet/labels/easy%20fix) _(label: easy fix)_ <br> JavaScript library for mobile-friendly interactive maps.
+- [Leaflet](https://github.com/Leaflet/Leaflet/labels/good%20first%20issue) _(label: good first issue)_ <br> JavaScript library for mobile-friendly interactive maps.
 - [angular-formly](https://github.com/formly-js/angular-formly/labels/first-timers-only) _(label: first-timers-only)_ <br> JavaScript powered forms for AngularJS.
 - [Dragula](https://github.com/bevacqua/dragula/labels/first-timers-only) _(label: first-timers-only)_ <br> Drag and drop so simple it hurts.
 - [UI.Layout directive (Angular UI)](https://github.com/angular-ui/ui-layout/labels/first-timers-only) _(label: first-timers-only)_ <br> Angular directive that allows you to split!


### PR DESCRIPTION
There are no issues for easy-fix label for the Leaflet repository, so I changed the link to the good first issue label where I think there are some doable issues for beginners to open source.