### PR TITLE
Fix TypeScript link to GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you are looking to contribute then explore this list, look at [`first-timers-
 
 ## TypeScript
 
-- [TypeScript](https://github.com/Microsoft/TypeScript/labels/Effort%3A%20Easy) _(label: Effort: Easy)_ <br>A superset of JavaScript that compiles to clean JavaScript output.
+- [TypeScript](https://github.com/Microsoft/TypeScript/labels/good%20first%20issue) _(label: good first issue)_ <br>A superset of JavaScript that compiles to clean JavaScript output.
 - [Visual Studio Code](https://github.com/Microsoft/vscode/labels/good%20first%20issue) _(label: good first issue)_ <br>A new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
 - [TSLint](https://github.com/palantir/tslint/labels/good%20first%20issue) _(label: good first issue)_ <br>An extensible static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
 


### PR DESCRIPTION
The TypeScript label wasn't directing to the correct label