### PR TITLE
Add Cookiesense under TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Jest](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) _(label: good first issue 👋)_ <br> A complete and easy to set up JavaScript testing solution.
 - [Mattermost](https://github.com/mattermost/mattermost-server/issues?q=is%3Aopen+label%3A%22Up+For+Grabs%22+label%3A%22Difficulty%3A+Introductory%22+label%3AReactJS) _(label: Up For Grabs, Difficulty: Introductory, ReactJS)_ <br> Open source Slack-alternative in Golang and React
 - [p5.js](https://github.com/processing/p5.js/labels/good%20first%20issue) _(label: good first issue)_ <br> p5.js is a client-side JS platform that empowers artists, designers, students, and anyone to learn to code and express themselves creatively on the web.
-- [cookiesense](https://github.com/MattL019/cookiesense/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+) _(label: good first issue)_ <br> cookiesense is a client-side cookie consent manager, allowing you to easily request cookie permission from users with minimal effort
 
 ## Julia
 
@@ -175,7 +174,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Visual Studio Code](https://github.com/Microsoft/vscode/labels/good%20first%20issue) _(label: good first issue)_ <br>A new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
 - [TSLint](https://github.com/palantir/tslint/labels/good%20first%20issue) _(label: good first issue)_ <br>An extensible static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
 - [tslint-eslint-rules](https://github.com/buzinas/tslint-eslint-rules/labels/nice%20first%20contribution) _(label: nice first contribution)_ <br> ESLint rules for TSLint.
-
+- [cookiesense](https://github.com/MattL019/cookiesense/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+) _(label: good first issue)_ <br> cookiesense is a client-side cookie consent manager, allowing you to easily request cookie permission from users with minimal effort written in TypeScript
 ## Contribute
 
 Contributions are welcome! See the [contribution guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [TSLint](https://github.com/palantir/tslint/labels/good%20first%20issue) _(label: good first issue)_ <br>An extensible static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
 - [tslint-eslint-rules](https://github.com/buzinas/tslint-eslint-rules/labels/nice%20first%20contribution) _(label: nice first contribution)_ <br> ESLint rules for TSLint.
 - [cookiesense](https://github.com/MattL019/cookiesense/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+) _(label: good first issue)_ <br> cookiesense is a client-side cookie consent manager, allowing you to easily request cookie permission from users with minimal effort written in TypeScript
+
 ## Contribute
 
 Contributions are welcome! See the [contribution guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Jest](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) _(label: good first issue 👋)_ <br> A complete and easy to set up JavaScript testing solution.
 - [Mattermost](https://github.com/mattermost/mattermost-server/issues?q=is%3Aopen+label%3A%22Up+For+Grabs%22+label%3A%22Difficulty%3A+Introductory%22+label%3AReactJS) _(label: Up For Grabs, Difficulty: Introductory, ReactJS)_ <br> Open source Slack-alternative in Golang and React
 - [p5.js](https://github.com/processing/p5.js/labels/good%20first%20issue) _(label: good first issue)_ <br> p5.js is a client-side JS platform that empowers artists, designers, students, and anyone to learn to code and express themselves creatively on the web.
+- [cookiesense](https://github.com/MattL019/cookiesense/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+) _(label: good first issue)_ <br> cookiesense is a client-side cookie consent manager, allowing you to easily request cookie permission from users with minimal effort
 
 ## Julia
 


### PR DESCRIPTION
Added my own open source project CookieSense. It's a cookie-consent manager allowing you to easily add a cookie-consent popup with one line of code. I'm hoping to attract more users to this project, as I believe it's perfect for first pr

(fixed spacing issue)