### PR TITLE
Fix label tag for Twitter Util

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 
 ## Scala
 
-- [Twitter Util](https://github.com/twitter/util/labels/Starter) _(label: Starter)_ <br> Wonderful reusable code from Twitter
+- [Twitter Util](https://github.com/twitter/util/labels/good%20first%20issue) _(label: good first issue)_ <br> Wonderful reusable code from Twitter
 - [playframework](https://github.com/playframework/playframework/labels/good%20first%20issue) _(label: good first issue)_ <br>The High Velocity Web Framework
 
 ## TypeScript


### PR DESCRIPTION
Twitter's Util repo uses "good first commit" instead of "Starter" as a label.

Link and description fixed in the attached PR