### PR TITLE
Add  Godot October's beginner friendly label

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 ## C++
 
 - [electron](https://github.com/electron/electron/labels/good%20first%20issue) _(label: good first issue)_ <br> Build cross platform desktop apps with JavaScript, HTML, and CSS
-- [Godot Engine](https://github.com/godotengine/godot/labels/junior%20job) _(label: junior job)_ <br> 2D and 3D cross-platform game engine. Also has C# and Python code.
+- [Godot Engine](https://github.com/godotengine/godot/labels/junior%20job) _(label: junior job or [Hacktoberfest](https://github.com/godotengine/godot/labels/Hacktoberfest) during October)_ <br> 2D and 3D cross-platform game engine. Also has C# and Python code.
 - [tensorflow](https://github.com/tensorflow/tensorflow/labels/stat%3Acontributions%20welcome) _(label: stat:contributions welcome)_ <br> Computation using data flow graphs for scalable machine learning
 
 ## Clojure


### PR DESCRIPTION
During October, the label junior job points to no issues because it is replaced with the Hacktoberfest one.
During the rest of the year the issues return to their normal label.

Note: I read the [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md) and saw that the format suggests to have one beginner friendly label associated to every repository. 
But being a beginner to the open source projects and after [opening an issue](https://github.com/godotengine/godot-docs/issues/1816) to clear things up with the godot-docs team, I think it is useful to do it here too. 