### PR TITLE
dartlang.org -> dart.dev; remove site-webdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 
 ## Dart
 
-- [webdev.dartlang.org](https://github.com/dart-lang/site-webdev/labels/beginner) _(label: beginner)_ <br> A website for developers writing Dart web apps, including AngularDart apps.
-- [www.dartlang.org](https://github.com/dart-lang/site-www/labels/beginner) _(label: beginner)_ <br> A website covering the Dart language and common libraries, for developers of Dart libraries, web apps, server-side code, and mobile (Flutter) apps.
+- [dart.dev](https://github.com/dart-lang/site-www/labels/beginner) _(label: beginner)_ <br> A website covering the Dart language and common libraries, for developers of Dart libraries, web apps, server-side code, and mobile (Flutter) apps.
 
 ## Elixir
 


### PR DESCRIPTION
We've moved the content of webdev.dartlang.org (site-webdev) to two new sites: dart.dev (site-www) and angulardart.dev (site-angulardart, which isn't ready for contributors at this time).