### PR TITLE
maint: remove mcollective

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 ## Ruby
 
 - [JRuby](https://github.com/jruby/jruby/labels/beginner) _(label: beginner)_ <br> An implementation of Ruby on the Java Virtual Machine.
-- [puppet-mcollective](https://github.com/puppet-community/puppet-mcollective/labels/beginner%20friendly) _(label: beginner friendly)_ <br> MCollective Server and Client Puppet Module.
 - [Sinatra](https://github.com/sinatra/sinatra/labels/good%20first%20issue) _(label: good first issue)_ <br> Classy web-development dressed in a DSL.
 - [Goby](https://github.com/nskins/goby) _(label: beginner)_ <br> Framework for developing text-RPGs.
 - [Hanami](https://github.com/hanami/hanami/labels/easy) _(label: easy)_ <br> A modern framework for Ruby.


### PR DESCRIPTION
mcollective has been deprecated and is no longer under active development, so I removed this listing. I'll see if I can find another repo with labels that we have that would be appropriate for beginners and file a separate PR