### PR TITLE
Add Roc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Godot Engine](https://github.com/godotengine/godot/labels/junior%20job) _(label: junior job)_ <br> 2D and 3D cross-platform game engine. Also has C# and Python code.
 - [tensorflow](https://github.com/tensorflow/tensorflow/labels/stat%3Acontributions%20welcome) _(label: stat:contributions welcome)_ <br> Computation using data flow graphs for scalable machine learning
 - [projectM](https://github.com/projectM-visualizer/projectm/labels/good%20first%20issue) _(label: good first issue)_ <br> A music visualizer library using OpenGL and GLSL. Has applications using Qt5, SDL, emscripten, iTunes, Kodi. 
+- [Roc](https://github.com/roc-project/roc/labels/help%20wanted) _(label: help wanted)_ <br> A toolkit for real-time audio streaming over the network.
 
 ## Clojure
 


### PR DESCRIPTION
Add Roc project, a toolkit for real-time audio streaming over the network:
https://github.com/roc-project/roc/

I'm the maintainer.

Though the issues tagged with "help wanted" are not for complete beginners, most of them should be quite OK for students and young developers, I think.