### PR TITLE
Fixed documentation typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Make sure your text editor is set to remove trailing whitespace.
 - The pull request and commit should have a useful title.
 - Make sure to give a description about your pull request.
-- If label does not clearly state its "beginner friendly" purpose, please make sure to confirm with maintainer that it is used for such issues. Please include the link to where maintainer confirms it in the PR. See examples below:
+- If label does not clearly state its "beginner friendly" purpose, please make sure to confirm with maintainer that it is used for such issues. Please include the link to where maintainer confirms it in the PR. Please See examples below:
   - Repository called "HornsAndHoovesJs" has label `good-first-contribution`. This PR does not need to be confirmed with the maintainer and can be merged straight away.
   - Repository called "bicycle-wheels-php" has label `easy`. This PR must be confirmed with the maintainer of "bicycle-wheels-php". The issue link where the maintainer confirms that label `easy` is used in the repository for beginner-friendly tasks has to be provided in the PR description.
 - Maintainer confirmation is also required in case repository has more than one beginner-friendly-like label (e.g. `low-hanging-fruit` and `up-for-grabs`).


### PR DESCRIPTION
Please complete the following checklist if your PR is adding new link to the list:

- [ ] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [ ] This PR does not introduce duplicates to the list
- [ ] The link is added at the bottom of the list category
- [ ] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [ ] The link I add follows suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
