### PR TITLE
Update README.md to add Q# training

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Perl](#perl)
 - [PHP](#php)
 - [Python](#python)
+- [Q#](#q-sharp)
 - [Ruby](#ruby)
 - [Rust](#rust)
 - [Scala](#scala)
@@ -217,6 +218,10 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [tree-sitter-legesher-python](https://github.com/legesher/tree-sitter-legesher-python/labels/Good%20First%20Issue) _(label: Good First Issue)_ <br> Learn and code in Python using your native language.
 - [mypy](https://github.com/python/mypy/labels/good-first-issue) _(label: good-first-issue)_ <br> An optional static typing for python.
 - [python-ds](https://github.com/prabhupant/python-ds/labels/good%20first%20issue) _(label: good first issue)_ <br> A repository for data structures and algorithms in Python.
+
+## <a name="q-sharp"></a>Q#
+
+- [Quantum Katas](https://github.com/Microsoft/QuantumKatas) _(label: beginner)_ <br> Programming exercises for learning Q# and quantum computing
 
 ## Ruby
 


### PR DESCRIPTION
Added a category for Microsoft's .NET-based Q# quantum programming language, as well as a link to the Q# training materials Microsoft has provided on GitHub in the form of Quantum Katas

Please complete the following checklist if your PR is adding new link to the list:

- [X] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [X] This PR does not introduce duplicates to the list
- [X] The link is added at the bottom of the list category
- [X] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [X] The link I add follows suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
