### PR TITLE
Fix ToC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 
 - [.NET](#net)
 - [C](#c)
-- [C#](#c-sharp)
-- [C++](#c-1)
+- [C#](#c-1)
+- [C++](#c-2)
 - [Clojure](#clojure)
 - [ClojureScript](#clojurescript)
 - [Dart](#dart)


### PR DESCRIPTION
The C++ link was pointing to the C# header.

---

Please complete the following checklist if your PR is adding new link to the list:

- [ ] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [ ] This PR does not introduce duplicates to the list
- [ ] The link is added at the bottom of the list category
- [ ] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [ ] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
