### PR TITLE
Add httpexpect

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Terraform](https://github.com/hashicorp/terraform/labels/good%20first%20issue) _(label: good first issue)_ <br> A tool for building, changing, and versioning infrastructure safely and efficiently.
 - [TiDB](https://github.com/pingcap/tidb/labels/for%20new%20contributors) _(label: for new contributors)_ <br> A distributed scalable Hybrid Transactional and Analytical Processing (HTAP) database
 - [script](https://github.com/bitfield/script/labels/good%20first%20issue) _(label: good first issue)_ <br> A Go library for doing the kind of tasks that shell scripts are good at: reading files, executing subprocesses, counting lines, matching strings, and so on. Beginners are very welcome and will get detailed code review and help through the PR process.
+- [httpexpect](https://github.com/gavv/httpexpect/labels/help%20wanted) _(label: help wanted)_ <br> End-to-end HTTP and REST API testing for Go.
 
 ## Java
 


### PR DESCRIPTION
httpexpect is a Go library for end-to-end HTTP API testing.

Please complete the following checklist if your PR is adding new link to the list:

- [x] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [x] This PR does not introduce duplicates to the list
- [x] The link is added at the bottom of the list category
- [x] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [x] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
