### PR TITLE
Add Ultra TabSaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ A Svelte/Sapper based <a href="https://github.com/sirixdb/sirix-svelte-front-end
 ## Swift
 
 - [OpenFoodFacts-iOS](https://github.com/openfoodfacts/openfoodfacts-ios/labels/help%20wanted) _(label: help wanted)_ <br>Collaborative, free and open database of food products from around the world. Scan barcode to get info or add a product
-- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver)_(label: good first contribution)_<br>The open source Tab Manager for Safari.
+- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver) _(label: good first contribution)_<br>The open source Tab Manager for Safari.
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ A Svelte/Sapper based <a href="https://github.com/sirixdb/sirix-svelte-front-end
 ## Swift
 
 - [OpenFoodFacts-iOS](https://github.com/openfoodfacts/openfoodfacts-ios/labels/help%20wanted) _(label: help wanted)_ <br>Collaborative, free and open database of food products from around the world. Scan barcode to get info or add a product
+- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver)_(label:good first contribution)_<br>The open source Tab Manager for Safari.
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ A Svelte/Sapper based <a href="https://github.com/sirixdb/sirix-svelte-front-end
 ## Swift
 
 - [OpenFoodFacts-iOS](https://github.com/openfoodfacts/openfoodfacts-ios/labels/help%20wanted) _(label: help wanted)_ <br>Collaborative, free and open database of food products from around the world. Scan barcode to get info or add a product
-- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver)_(label:good first contribution)_<br>The open source Tab Manager for Safari.
+- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver)_(label: good first contribution)_<br>The open source Tab Manager for Safari.
 
 ## TypeScript
 


### PR DESCRIPTION
Ultra TabSaver is an open source Tab Manager for Safari.

- [x] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [x] This PR does not introduce duplicates to the list
- [x] The link is added at the bottom of the list category
- [x] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [x] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver) _(label: good first contribution)_<br>The open source Tab Manager for Safari.
```
