### PR TITLE
Updating FreeCodeCamp lable to currently used first timer tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Tessel 2 CLI](https://github.com/tessel/t2-cli/labels/contribution-starter) _(label: contribution-starter)_ <br> Command line interface to Tessel 2.
 - [Ember.js](https://github.com/emberjs/ember.js/labels/Good%20for%20New%20Contributors) _(label: Good for New Contributors)_ <br> A JavaScript framework for creating ambitious web applications.
 - [Ember.js Data](https://github.com/emberjs/data/labels/Good%20for%20New%20Contributors) _(label: Good for New Contributors)_ <br> A data persistence library for Ember.js.
-- [FreeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp/labels/first%20timers%20welcome) _(label: first timers welcome)_ <br> Open source codebase and curriculum. Learn to code and help nonprofits.
+- [FreeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp/labels/first%20timers%20only) _(label: first timers only)_ <br> Open source codebase and curriculum. Learn to code and help nonprofits.
 - [Ghost](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) _(label: good first issue)_ <br> Just a blogging platform
 - [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn/labels/good%20for%20beginner) _(label: good for beginner)_ <br> Awesome ESLint rules.
 - [Hyper](https://github.com/zeit/hyper/labels/good%20first%20issue) _(label: good first issue)_ <br> JS/HTML/CSS Terminal


### PR DESCRIPTION
I was running around checking your awesome list, and noticed that FreeCodeCamp didn't have any issues listed.  However I could go look at the full issue list and see some first timer issues.

It turns out the link and tag this list was looking for was using "first timers welcome" but the FreeCodeCamp repo apparently has changed to "first timers only".

Rather than trying to send in an issue, I figured I'd just fix your list and try my first pull request.  Let me know if I've done anything wrong with this, or didn't follow the process below (I figured I'd get some passes since this is a existing link, and not a new link, so I maintained the current list order etc.)

Please complete the following checklist if your PR is adding new link to the list:

- [X] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [X] This PR does not introduce duplicates to the list
- [ ] The link is added at the bottom of the list category
- [X] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [X] The link I add follows the suggested pattern[...]

Old Label:
![image](https://user-images.githubusercontent.com/1844516/86652329-50dd8480-bfb2-11ea-84a9-f705f35f046a.png)

New Label:
![image](https://user-images.githubusercontent.com/1844516/86652461-6fdc1680-bfb2-11ea-88a8-5c577e8be86c.png)
