### PR TITLE
Add Killgrave on Go section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [TiDB](https://github.com/pingcap/tidb/labels/for%20new%20contributors) _(label: for new contributors)_ <br> A distributed scalable Hybrid Transactional and Analytical Processing (HTAP) database
 - [script](https://github.com/bitfield/script/labels/good%20first%20issue) _(label: good first issue)_ <br> A Go library for doing the kind of tasks that shell scripts are good at: reading files, executing subprocesses, counting lines, matching strings, and so on. Beginners are very welcome and will get detailed code review and help through the PR process.
 - [httpexpect](https://github.com/gavv/httpexpect/labels/help%20wanted) _(label: help wanted)_ <br> End-to-end HTTP and REST API testing for Go.
+- [Killgrave](https://github.com/friendsofgo/killgrave/labels/good%20first%20issue) _(label: good first issue)_ <br> Simple way to generate mock servers in Go.
 
 ## Java
 


### PR DESCRIPTION
### Pre-checks

Please complete the following checklist if your PR is adding new link to the list:

- [X] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [X] This PR does not introduce duplicates to the list
- [X] The link is added at the bottom of the list category
- [X] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [X] The link I add follows the suggested pattern.

### Changes

It adds the [Killgrave](https://github.com/friendsofgo/killgrave) project which is actively maintained by [Friends of Go](https://github.com/friendsofgo) community members and some individual contributors.

cc/ @MunGell  