### PR TITLE
Add the Qual-ID repo to the Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 - [datascience](https://github.com/data-8/datascience/labels/good%20first%20issue) _(label: good first issue)_ <br> A Jupyter notebook Python library for introductory data science.
 - [ArviZ](https://github.com/arviz-devs/arviz/labels/Beginner) _(label: Beginner)_ <br> Exploratory Anaylsis of Bayesian Models.
 - [MindsDB](https://github.com/mindsdb/mindsdb/labels/good%20first%20issue) _(label: good first issue)_ <br> MindsDB is an open source AI layer for existing databases.
+- [Qual ID](https://github.com/gabrielbarker/qual-id/labels/beginner%20friendly) _(label: beginner friendly)_ <br> A RESTful API that returns randomly generated, custom _qualitative ID's_.
 
 ## Ruby
 


### PR DESCRIPTION
- [X] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [X] This PR does not introduce duplicates to the list
- [X] The link is added at the bottom of the list category
- [X] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [X] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Actual link

```
- [Qual ID](https://github.com/gabrielbarker/qual-id/labels/beginner%20friendly) _(label: beginner friendly)_ <br> A RESTful API that returns randomly generated, custom _qualitative ID's_.
```

Hey @MunGell , I've added my repo to the list of python projects. I specifically made the repo to help beginners make meaningful first contributions.

Thanks!
