### PR TITLE
Fixed C# osu! label

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 ## C#
 
 - [OpenRA](https://github.com/OpenRA/OpenRA/labels/Easy) _(label: Easy)_ <br> A Real Time Strategy game engine supporting early Westwood classics such as Command & Conquer: Red Alert.
-- [osu!](https://github.com/ppy/osu/labels/good%20first%20issue) _(label: good first issue)_ <br> Music game. Rhythm is just a *click* away!
+- [osu!](https://github.com/ppy/osu/labels/good-first-issue) _(label: good-first-issue)_ <br> Music game. Rhythm is just a *click* away!
 
 ## C++
 


### PR DESCRIPTION
Fixed C# osu! label since old one no longer works

Please complete the following checklist if your PR is adding new link to the list:

- [x] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [x] This PR does not introduce duplicates to the list
- [ ] The link is added at the bottom of the list category
- [ ] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [ ] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
