### PR TITLE
Adding Moveit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ If you are not a programmer, but would like to contribute, check out the [Awesom
 - [Roc Toolkit](https://github.com/roc-streaming/roc-toolkit/labels/help%20wanted) _(label: help wanted)_ <br> A toolkit for real-time audio streaming over the network.
 - [tensorflow](https://github.com/tensorflow/tensorflow/labels/stat%3Acontributions%20welcome) _(label: stat:contributions welcome)_ <br> Computation using data flow graphs for scalable machine learning
 - [Yugabyte DB](https://github.com/yugabyte/yugabyte-db/labels/good%20first%20issue) _(label: good first issue)_ <br> Distributed SQL database.
+- [MoveIt](https://github.com/ros-planning/moveit/labels/first-timer-only) _(label: first-timer-only)_ <br> Easy-to-use open source robotics manipulation platform for developing commercial applications, prototyping designs, and benchmarking algorithms.
 
 ## Clojure
 


### PR DESCRIPTION
Hi @MunGell,

thank you for maintaining this great collection of beginner-friendly repositories. To ease the start for beginners, MoveIt recently decided to introduce better-guided issues reserved for first-timers and labeled as "first-timer-only". We are an active and welcoming community and hope to help many new robotics enthusiasts getting started in the world of open-source robotics and motion planning :) Therefore, it would be great if you could add MoveIt to your list.

Thanks in advance!

Cheers,
Sebastian

Please complete the following checklist if your PR is adding new link to the list:

- [X] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [X] This PR does not introduce duplicates to the list
- [X] The link is added at the bottom of the list category
- [X] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [X] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
