### PR TITLE
Added awesome-resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 - [mapknitter](https://github.com/publiclab/mapknitter/labels/first-timers-only) _(label: first-timers-only)_ <br> Upload your own aerial images, position (rubbersheet) them in a web interface over existing map data, and share via web or composite and export for print.
 - [Ruby on Rails](https://github.com/rails/rails/labels/good%20first%20issue) _(label: good first issue)_ <br> Ruby on Rails (Rails) is an open source web application framework written in Ruby.
 - [Faker](https://github.com/faker-ruby/faker/labels/good%20first%20issue) _(label: good first issue)_ <br> Faker is a Ruby library for generating fake data such as names, addresses, and phone numbers.
+- [Awesome Resources](https://github.com/shahednasser/awesome-resources/labels/good%20first%20issue) _(label: good first issue)_ <br> List of helpful resources added by the community for the community!
 
 ## Rust
 


### PR DESCRIPTION
I added [awesome-resources](https://github.com/shahednasser/awesome-resources) repo under Ruby, since that is the main language for the Jekyll website. However, contributors who don't know ruby can contribute by adding resources of their own. If you think it should be added under another category please let me know.

Please complete the following checklist if your PR is adding new link to the list:

- [x] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [x] This PR does not introduce duplicates to the list
- [x] The link is added at the bottom of the list category
- [x] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [x] The link I add follows the suggested pattern:

```
- [Repository Name](link-to-repository-label) _(label: beginner-friendly-label-in-the-repository)_ <br> Description
```

Example link formatting:

```
- [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners/labels/good-first-contribution) _(label: good-first-contribution)_ <br> A list of awesome beginners-friendly projects.
```
