### PR TITLE
Suggest addition of jupyterlab-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 - [LitmusChaos](https://github.com/litmuschaos/litmus/labels/good%20first%20issue) _(label: good first issue)_ <br> Litmus is a toolset to do cloud-native chaos engineering.
 - [Booster](https://github.com/boostercloud/booster/labels/good%20first%20issue) _(label: good first issue)_ <br> A truly serverless framework, write your code and deploy it in seconds without any server configuration files.
 - [tinyhttp](https://github.com/talentlessguy/tinyhttp/labels/good%20first%20issue) _(label: good first issue)_ <br> A 0-legacy, tiny & fast web framework as a replacement of Express.
+- [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp/labels/good%20first%20issue) _(label: good first issue)_ <br> Coding assistance for JupyterLab (code navigation + hover suggestions + linters + autocompletion + rename)
 
 ## Contribute
 


### PR DESCRIPTION
I suggest to add [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) repository (which implements coding assistance for JupyterLab) where we maintain a list of issues dedicated to beginner contributors; our issues for beginners (`good first issue` and `documentation`):
- provide a description of what should be done (and what are the possible solutions)
- link to relevant parts of codebase
- are held for new contributors for at least two weeks since creation
 
We also a pretty detailed [`CONTRIBUTING.md`](https://github.com/krassowski/jupyterlab-lsp/blob/master/CONTRIBUTING.md) and as a co-maintainer I am willing to guide any newcomers. I added the project into Typescript category, although a sizeable portion includes a Python backend. It is not clear to me what we should do if a project fits into more than one category.

Please complete the following checklist if your PR is adding new link to the list:

- [x] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [x] This PR does not introduce duplicates to the list
- [x] The link is added at the bottom of the list category
- [x] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [x] The link I add follows the suggested pattern.