### PR TITLE
Updated label for cookiecutter-django

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 - [Jupyter notebook](https://github.com/jupyter/notebook/labels/good%20first%20issue) _(label: good first issue)_ <br> Jupyter interactive notebook.
 - [Zulip](https://github.com/zulip/zulip/labels/good%20first%20issue) _(label: good first issue)_ <br> Powerful open source group chat.
 - [cookiecutter](https://github.com/audreyr/cookiecutter/labels/low-hanging-fruit) _(label: low-hanging-fruit)_ <br> A command-line utility that creates projects from cookiecutters (project templates). E.g. Python package projects, jQuery plugin projects.
-- [django cookiecutter](https://github.com/pydanny/cookiecutter-django/labels/hacktoberfest) _(label: django hacktober special)_ <br> An implementation of Python for backend web development.
+- [django cookiecutter](https://github.com/pydanny/cookiecutter-django/labels/good%20first%20issue) _(label: good first issue)_ <br> An implementation of Python for backend web development.
 - [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide/labels/level%3Astarter) _(label: level:starter)_ <br> The strictest and most opinionated python linter ever!
 - [Ansible](https://github.com/ansible/ansible/labels/easyfix) _(label:easyfix)_ <br> A simple IT automation platform
 - [Create aio app](https://github.com/aio-libs/create-aio-app/labels/good%20first%20issue) _(label: good first issue)_ <br> A command line utility that creates the aiohttp template with the best practices.


### PR DESCRIPTION
The `hacktober` label is no longer in use (last issue was in 2019), so I updated the label to `good first issue` which is the actively used label for  beginner friendly issues.