### PR TITLE
Add pythonping in Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 - [Pytorch](https://github.com/pytorch/pytorch/labels/good%20first%20issue) _(label: Good first issue)_ <br> PyTorch is an open source machine learning library based on the Torch library, used for applications such as computer vision and natural language processing.
 - [Sorting-Algorithms-Visualizer](https://github.com/LucasPilla/Sorting-Algorithms-Visualizer/labels/good%20first%20issue) _(label: good first issue)_ <br> A tool for visualizing sorting algorithms with a educational Wiki Page.
 - [scikit-learn](https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue) _(label: good first issue)_ <br> Scikit-learn is a machine learning library for Python.
+- [pythonping](https://github.com/alessandromaggio/pythonping/labels/good%20first%20issue) _(label: good first issue)_ <br> PythonPing is a simple library to execute ICMP pings natively in Python without resorting to spawning a shell.
 
 ## Ruby
 


### PR DESCRIPTION
Added pythonping, a simple library to executeICMP pings natively in Python without resorting to spawning a shell.

Please complete the following checklist if your PR is adding new link to the list:

- [v] I've read [contributing guidelines](https://github.com/MunGell/awesome-for-beginners/blob/master/CONTRIBUTING.md)
- [v] This PR does not introduce duplicates to the list
- [v] The link is added at the bottom of the list category
- [v] Suggested repository is maintained, have active community, is able to mentor new contributors and have issues with the suggested label
- [v] The link I add follows the suggested pattern:
