### PR TITLE
Fix the Rust-Clippy link and label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 ## Rust
 
 - [Servo](https://github.com/servo/servo/labels/E-easy) _(label: E-easy)_ <br> A browser engine designed for applications including embedded use.
-- [Rust-Clippy](https://github.com/rust-lang-nursery/rust-clippy/labels/good%20first%20issue) _(label: good first issue)_  <br> A bunch of lints to catch common mistakes and improve Rust code
+- [Rust-Clippy](https://github.com/rust-lang-nursery/rust-clippy/labels/good-first-issue) _(label: good-first-issue)_  <br> A bunch of lints to catch common mistakes and improve Rust code
 - [Rustfmt](https://github.com/rust-lang-nursery/rustfmt/labels/good%20first%20issue) _(label: good first issue)_ <br> A tool for formatting Rust code according to style guidelines.
 - [Iron](https://github.com/iron/iron/labels/easy) _(label: easy)_ <br> An extensible, concurrent web framework for Rust
 - [TiKV](https://github.com/tikv/tikv/labels/difficulty%2Feasy) _(label: D: difficulty/easy)_ <br> A distributed transactional key-value database


### PR DESCRIPTION
The [current link](https://github.com/rust-lang-nursery/rust-clippy/labels/good%20first%20issue) to Rust-Clippy lists no issues because the label is `good-first-issue` with dashes instead of spaces. I've fixed both the link and the label next to it to reflect this.