### PR TITLE
Revert "Added tslint-eslint-rules under TypeScript (#209)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,6 @@ Habitica is a gamified task manager, webapp and android/ios app, really wonderfu
 
 - [TypeScript](https://github.com/Microsoft/TypeScript/labels/good%20first%20issue) _(label: good first issue)_ <br>A superset of JavaScript that compiles to clean JavaScript output.
 - [Visual Studio Code](https://github.com/Microsoft/vscode/labels/good%20first%20issue) _(label: good first issue)_ <br>A new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
-- [tslint-eslint-rules](https://github.com/buzinas/tslint-eslint-rules/labels/nice%20first%20contribution) _(label: nice first contribution)_ <br> ESLint rules for TSLint.
 - [reatom](https://github.com/artalar/reatom/labels/good%20first%20issue) _(label: good first issue)_ <br> Reatom is declarative and reactive state manager, designed for both simple and complex applications.
 - [game-of-life](https://github.com/TroyTae/game-of-life/labels/good%20first%20issue) _(label: good first issue)_ <br> Conway's Game of Life web version!
 - [Graphback](https://github.com/aerogear/graphback/labels/good%20first%20issue) _(label: good first issue)_ <br>A CLI and runtime framework to generate a GraphQL API in seconds.


### PR DESCRIPTION
This reverts commit a139582cdefd27411faf721b2cc13bde1b5c20b3 due to unmaintained and deprecated repo.
Source: https://github.com/buzinas/tslint-eslint-rules#deprecated
Related to https://github.com/MunGell/awesome-for-beginners/issues/1069