### PR TITLE
Remove Atom from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 - [Semantic-UI-React](https://github.com/Semantic-Org/Semantic-UI-React/labels/good%20first%20issue) _(label: good first issue)_ <br> The official React integration for Semantic UI.
 - [electron](https://github.com/electron/electron/labels/good%20first%20issue) _(label: good first issue)_ <br> Build cross platform desktop apps with JavaScript, HTML, and CSS
 - [Botpress](https://github.com/botpress/botpress/labels/good%20first%20issue) _(label: good first issue)_ <br> The only sane way to build great bots.
-- [Atom](https://github.com/atom/atom/labels/beginner) _(label: beginner)_ <br> The hackable text editor
 - [cdnjs](https://github.com/cdnjs/cdnjs/labels/good%20first%20issue) _(label: good first issue)_ <br> The best FOSS web front-end resource CDN
 - [Video.js](https://github.com/videojs/video.js/labels/first-timers-only) _(label: first-timers-only)_ <br> The player framework
 - [stryker](https://github.com/stryker-mutator/stryker/labels/beginner%20friendly) _(label: beginner friendly)_ <br> The JavaScript mutation testing framework


### PR DESCRIPTION
The last issue with the beginner tag was updated in 2019, and the whole project is [getting archived soon](https://github.blog/2022-06-08-sunsetting-atom/).

Checklist removed because this is *removing* a link, not adding one.
