### PR TITLE
Add Scribe-iOS to data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -2085,6 +2085,15 @@
                 ".NET"
             ],
             "description": "An extension framework to Legerity for speeding up the development of automated UI tests for Uno Platform applications with Appium/Selenium on .NET."
+        },
+        {
+            "name": "Scribe - Language Keyboards",
+            "link": "https://github.com/scribe-org/Scribe-iOS",
+            "label": "good first issue",
+            "technologies": [
+                "Swift"
+            ],
+            "description": "Keyboards for language learners with translation, verb conjugation and more!"
         }
     ]
 }


### PR DESCRIPTION
Hi there! 

Hoping that we can be added to this list. Scribe is still relatively new, but we're slowly making headway towards v2.0 that adds autocomplete and autosuggest - the last two must have features for a wider audience. The app's data is mostly from [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) and Wikipedia, and we're a [featured project](https://www.mediawiki.org/wiki/New_Developers) for developers who are new to Wikimedia :) 

Hope that everything's in order for the PR, and thanks for this list!