### PR TITLE
Add roc-go

### DIFF
--- a/data.json
+++ b/data.json
@@ -2085,6 +2085,15 @@
                 ".NET"
             ],
             "description": "An extension framework to Legerity for speeding up the development of automated UI tests for Uno Platform applications with Appium/Selenium on .NET."
+        },
+        {
+            "name": "Roc Go",
+            "link": "https://github.com/roc-streaming/roc-go/labels/good%20first%20issue",
+            "label": "good first issue",
+            "technologies": [
+                "Go"
+            ],
+            "description": "Go bindings for Roc Toolkit (real-time audio streaming)"
         }
     ]
 }


### PR DESCRIPTION
[roc-go](https://github.com/roc-streaming/roc-go) provides Go bindings for [Roc Toolkit](https://github.com/roc-streaming/roc-toolkit).

We recently released the first version of the bindings and now are looking for help, mostly with adding more tests.