### PR TITLE
Pion SFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 - [Elixir](https://github.com/elixir-lang/elixir) _(label: Level:Starter)_ <br> Elixir is a dynamic, functional language designed for building scalable and maintainable applications
 
 ## Go
-
+- [Pion SFU](https://github.com/pion/webrtc) _(label: good-first-issue)_  <br> Pion SFU is a pure Go implementation of the WebRTC API. It provides a flexible and extensible platform for building scalable video conferencing applications.
 - [containerd](https://github.com/containerd/containerd) _(label: exp/beginner)_ <br> Industry-standard container runtime with an emphasis on simplicity, robustness and portability.
 - [Docker/CLI](https://github.com/docker/cli) _(label: exp/beginner)_ <br> The Docker CLI
 - [Helm](https://github.com/kubernetes/helm) _(label: good-first-issue)_ <br> The Kubernetes Package Manager
@@ -100,6 +100,7 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 - [script](https://github.com/bitfield/script) _(label: good-first-issue)_ <br> A Go library for doing the kind of tasks that shell scripts are good at: reading files, executing subprocesses, counting lines, matching strings, and so on. Beginners are very welcome and will get detailed code review and help through the PR process.
 - [Terraform](https://github.com/hashicorp/terraform) _(label: good-first-issue)_ <br> A tool for building, changing, and versioning infrastructure safely and efficiently.
 - [TiDB](https://github.com/pingcap/tidb) _(label: for-new-contributors)_ <br> A distributed scalable Hybrid Transactional and Analytical Processing (HTAP) database
+
 
 ## Haskell
 

--- a/data.json
+++ b/data.json
@@ -210,6 +210,15 @@
             "description": "The Scalable, Survivable, Strongly-Consistent SQL Database"
         },
         {
+            "name": "WebRTC",
+            "link": "https://github.com/pion/webrtc",
+            "label": "good-first-issue",
+            "technologies": [
+                "Go"
+            ],
+            "description": "Pion SFU is a pure Go implementation of the WebRTC API. It provides a flexible and extensible platform for building scalable video conferencing applications."
+        },
+        {
             "name": "Docker/CLI",
             "link": "https://github.com/docker/cli",
             "label": "exp/beginner",


### PR DESCRIPTION
 Pion SFU is a pure Go implementation of the WebRTC API. It provides a flexible and extensible platform for building scalable video conferencing applications.