### PR TITLE
Fixed broken hyperlink of Discourse -- Issue: #1294 

### DIFF
--- a/data.json
+++ b/data.json
@@ -1663,7 +1663,7 @@
         },
         {
             "name": "Discourse",
-            "link": "https://meta.discourse.org/tags/starter-task",
+            "link": "https://github.com/discourse/discourse",
             "technologies": [
                 "Ruby"
             ],

--- a/data.json
+++ b/data.json
@@ -1662,14 +1662,6 @@
             "description": "An open source publishing platform for environmental projects. Check out new contributors welcome page."
         },
         {
-            "name": "Discourse",
-            "link": "https://github.com/discourse/discourse",
-            "technologies": [
-                "Ruby"
-            ],
-            "description": "Civilized discussion platform. See \"How to contribute to Discourse\"."
-        },
-        {
             "name": "osem",
             "link": "https://github.com/openSUSE/osem",
             "label": "good-first-issue",


### PR DESCRIPTION
I have noticed an issue: #1294, I have updated the hyperlink with a new GitHub hyperlink of discourse. 