### PR TITLE
Fixed the broken discourse hyperlink | Broken hyperlink #1294

### DIFF
--- a/data.json
+++ b/data.json
@@ -1663,7 +1663,7 @@
         },
         {
             "name": "Discourse",
-            "link": "https://meta.discourse.org/tags/starter-task",
+            "link": "https://meta.discourse.org/tag/getting-started",
             "technologies": [
                 "Ruby"
             ],


### PR DESCRIPTION
I've fixed the broken hyperlink for discourse found in README.md