### PR TITLE
Add Go-Fast CDN

### DIFF
--- a/data.json
+++ b/data.json
@@ -344,6 +344,16 @@
             "description": "Meshery, the service mesh management plane."
         },
         {
+            "name": "Go-Fast CDN",
+            "link": "https://github.com/kevinanielsen/go-fast-cdn",
+            "label": "good-first-issue",
+            "technologies": [
+                "Go",
+                "TypeScript"
+            ],
+            "description": "A fast and simple CDN written in Go and Vite/React all embedded in one executable, making it easy to dockerize."
+        },
+        {
             "name": "Strongbox",
             "link": "https://github.com/strongbox/strongbox",
             "label": "good-first-issue",


### PR DESCRIPTION
Added [Go-Fast CDN](https://github.com/kevinanielsen/go-fast-cdn) to the list - A simple and fast CDN written in Go and React/TypeScript meant for beginner programmers and self-hosting purposes. 

The project has around 30 stars and a little under 10 contributors, it features a CONTRIBUTING.md file, well-written documentation for development and contribution, and is actively maintained.