### PR TITLE
Update Time to Leave label

### DIFF
--- a/data.json
+++ b/data.json
@@ -975,7 +975,7 @@
         {
             "name": "Time to Leave",
             "link": "https://github.com/thamara/time-to-leave",
-            "label": "good-first-issue",
+            "label": "good first issue",
             "technologies": [
                 "JavaScript"
             ],


### PR DESCRIPTION
The good first issue label in the Time to Leave repository has been changed from 'good-first-issue' to 'good first issue'
This PR reflects that change.