### PR TITLE
Docs/flutter link text adjustments

### DIFF
--- a/data.json
+++ b/data.json
@@ -1995,7 +1995,7 @@
         {
             "name": "flutter",
             "link": "https://github.com/flutter/flutter",
-            "label": "good first contribution",
+            "label": "good first issue",
             "technologies": [
                 "Dart"
             ],

--- a/data.json
+++ b/data.json
@@ -1994,7 +1994,7 @@
         },
         {
             "name": "flutter",
-            "link": "https://github.com/flutter/flutter",
+            "link": "https://github.com/flutter/flutter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22",
             "label": "good first issue",
             "technologies": [
                 "Dart"


### PR DESCRIPTION
**Updates Link:** Replaces the existing link to "good first issues" with a direct link to the filtered issue list on GitHub. This makes it much easier for new contributors to find suitable starting points.
**Updates Label:** Changes the label from "good first contribution" to "good first issue" to match the commonly used terminology on the flutter repository. 

**Why these changes are helpful:**

Reduces Friction for Newcomers: New contributors can immediately jump into the issue list without having to figure out how to filter, and the consistent terminology reduces confusion.
Encourages Contributions: A more intuitive process can attract more people to get involved with the Flutter project.
Testing:

**I've verified that:**

The new link correctly directs to the filtered list of "Good First Issues" on GitHub.
The updated label "Good First Issue" is displayed correctly in the documentation.