### PR TITLE
Fix Kanister link in data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -247,7 +247,7 @@
         },
         {
             "name": "Kanister",
-            "link": "https://github.com/kanisteroio/kanister",
+            "link": "https://github.com/kanisterio/kanister",
             "label": "good-first-issue",
             "technologies": [
                 "Go"


### PR DESCRIPTION
Fixed subtle error in the hyperlink to the Kanister repository