### PR TITLE
Removed inactive repo Binari from data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -937,15 +937,6 @@
             "description": "Ramda Adjunct is the most popular and most comprehensive set of functional utilities for use with Ramda, providing a variety of useful, well tested functions with excellent documentation."
         },
         {
-            "name": "Binari",
-            "link": "https://github.com/BrandonArmand/Binari",
-            "label": "up-for-grabs",
-            "technologies": [
-                "JavaScript"
-            ],
-            "description": "Interactive code editor with a live binary tree visual designed to teach new developers the fundementals of dynamic programming."
-        },
-        {
             "name": "SirixDB",
             "link": "https://github.com/sirixdb/sirix-svelte-front-end",
             "label": "good-first-issue",


### PR DESCRIPTION
The repository has been inactive for nine months so I reckoned it should be taken off.