### PR TITLE
Cleaned up TypeScript category in data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -2174,7 +2174,7 @@
             "label": "good first issue",
             "technologies": [
                 "Python",
-                "Typescript",
+                "TypeScript",
                 "Angular"
             ],
             "description": "Oppia is an open-source project whose aim is to empower learners across the globe by providing access to high-quality, engaging education. We envision a society in which access to high-quality education is a human right rather than a privilege."


### PR DESCRIPTION
Two different spellings meant that two categories were being made for them.
This appeared in the categories section as:
<img width="167" alt="image" src="https://github.com/user-attachments/assets/d1a49f15-a44a-4841-b792-f6fcbd7ce3b9">

I have normalised the capitalisation of the "Script" in TypeScript to fix this issue.