### PR TITLE
Remove zeit (now vercel)/hyper for inactivity

### DIFF
--- a/data.json
+++ b/data.json
@@ -595,15 +595,6 @@
             "description": "Awesome ESLint rules."
         },
         {
-            "name": "Hyper",
-            "link": "https://github.com/zeit/hyper",
-            "label": "good first issue",
-            "technologies": [
-                "JavaScript"
-            ],
-            "description": "JS/HTML/CSS Terminal"
-        },
-        {
             "name": "API-pull-with-JavaScript",
             "link": "https://github.com/AliBasboga/APIExampleWithExpress.git",
             "label": "API-pull-and-use",


### PR DESCRIPTION
This repo has been inactive for 8 months.
This one is a little surprising as there seems to be no announcement about development being stopped on this, despite the fact that Vercel is quite a big organisation (they made Next.js).

Someone did open an issue (vercel/hyper#8043) asking about development over two months ago but haven't had a reply yet.