### PR TITLE
Update The TiDB label

### DIFF
--- a/data.json
+++ b/data.json
@@ -293,7 +293,7 @@
         {
             "name": "TiDB",
             "link": "https://github.com/pingcap/tidb",
-            "label": "for-new-contributors",
+            "label": "good first issue",
             "technologies": [
                 "Go"
             ],


### PR DESCRIPTION
Update the label name of the TiDB repository from "for-new-contributors" to "good first issue".