### PR TITLE
Move Alda to go projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ If you would like to be guided through how to contribute to a repository on GitH
 
 ## Clojure
 
-- [Alda](https://github.com/alda-lang/alda) _(label: low-hanging-fruit)_ <br> A music programming language for musicians. 🎶
 - [Metabase](https://github.com/metabase/metabase) _(label: good first issue)_ <br> Open source business intelligence and analytics platform
 
 ## Dart
@@ -94,6 +93,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 
 ## Go
 
+- [Alda](https://github.com/alda-lang/alda) _(label: low-hanging-fruit)_ <br> A music programming language for musicians. 🎶
 - [containerd](https://github.com/containerd/containerd) _(label: exp/beginner)_ <br> Industry-standard container runtime with an emphasis on simplicity, robustness and portability.
 - [Docker/CLI](https://github.com/docker/cli) _(label: exp/beginner)_ <br> The Docker CLI
 - [Dragonfly](https://github.com/dragonflyoss/Dragonfly2) _(label: good first issue)_ <br> Provide efficient, stable and secure file distribution and image acceleration based on p2p technology


### PR DESCRIPTION
Alda is not a clojure project anymore, the majority of it is written in go now.