### PR TITLE
convert alda to go project

### DIFF
--- a/data.json
+++ b/data.json
@@ -171,7 +171,7 @@
             "link": "https://github.com/alda-lang/alda",
             "label": "low-hanging-fruit",
             "technologies": [
-                "Clojure"
+                "Go"
             ],
             "description": "A music programming language for musicians. 🎶"
         },


### PR DESCRIPTION
Alda is written in Go for the majority of the codebase, it was converted to clojure long time ago.