### PR TITLE
Removed python repos that does not seem fit

### DIFF
--- a/data.json
+++ b/data.json
@@ -1462,15 +1462,6 @@
             "description": "The webservice for gpodder.net, a libre web service that allows users to manage their podcast subscriptions and discover new content."
         },
         {
-            "name": "tree-sitter-legesher-python",
-            "link": "https://github.com/legesher/tree-sitter-legesher-python",
-            "label": "Good-First-Issue",
-            "technologies": [
-                "Python"
-            ],
-            "description": "Learn and code in Python using your native language."
-        },
-        {
             "name": "mypy",
             "link": "https://github.com/python/mypy",
             "label": "good first issue",

--- a/data.json
+++ b/data.json
@@ -1938,15 +1938,6 @@
             "description": "Amplication is an open-source development tool. It helps you develop quality Node.js applications without spending time on repetitive coding tasks."
         },
         {
-            "name": "pythonping",
-            "link": "https://github.com/alessandromaggio/pythonping",
-            "label": "good first issue",
-            "technologies": [
-                "Python"
-            ],
-            "description": "PythonPing is a simple library to execute ICMP pings natively in Python without resorting to spawning a shell."
-        },
-        {
             "name": "flutter",
             "link": "https://github.com/flutter/flutter",
             "label": "good first issue",

--- a/data.json
+++ b/data.json
@@ -1345,14 +1345,6 @@
             "description": "An interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers"
         },
         {
-            "name": "coala",
-            "link": "https://github.com/coala/coala",
-            "technologies": [
-                "Python"
-            ],
-            "description": "A unified command-line interface for linting and fixing all your code, regardless of the programming languages you use."
-        },
-        {
             "name": "jarvis",
             "link": "https://github.com/sukeesh/Jarvis",
             "label": "difficulty/newcomer",

--- a/data.json
+++ b/data.json
@@ -1543,15 +1543,6 @@
             "description": "PyTorch is an open source machine learning library based on the Torch library, used for applications such as computer vision and natural language processing."
         },
         {
-            "name": "Sorting-Algorithms-Visualizer",
-            "link": "https://github.com/LucasPilla/Sorting-Algorithms-Visualizer",
-            "label": "good first issue",
-            "technologies": [
-                "Python"
-            ],
-            "description": "A tool for visualizing sorting algorithms with a educational Wiki Page."
-        },
-        {
             "name": "scikit-learn",
             "link": "https://github.com/scikit-learn/scikit-learn",
             "label": "good first issue",


### PR DESCRIPTION
Some of the Python repos are not good starting points for beginners (any more at least). To keep the list clean I removed those repos from data.json that have too few recent activity or no beginner friendly issues. Or both.

I've put each removal in a separate commit so they may be cherry-picked easily.