### PR TITLE
Add a warning in README-template.j2 - links open in the same tab

### DIFF
--- a/.github/README-template.j2
+++ b/.github/README-template.j2
@@ -13,8 +13,8 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 
 If you would like to be guided through how to contribute to a repository on GitHub, check out [the First Contributions repository](https://github.com/firstcontributions/first-contributions).
 
-⚠️ **Note:** All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
-
+> [!TIP]
+> All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
 ## Table of Contents:
 
 ||Languages|

--- a/.github/README-template.j2
+++ b/.github/README-template.j2
@@ -13,6 +13,8 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 
 If you would like to be guided through how to contribute to a repository on GitHub, check out [the First Contributions repository](https://github.com/firstcontributions/first-contributions).
 
+⚠️ **Note:** All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
+
 ## Table of Contents:
 
 ||Languages|


### PR DESCRIPTION
In addition to this warning, added a tip on how to open a link in a new tab.

Resolves #1542