### PR TITLE
add wordpress to php

### DIFF
--- a/data.json
+++ b/data.json
@@ -1212,6 +1212,15 @@
             "description": "Symfony is a PHP framework for web applications and a set of reusable PHP components."
         },
         {
+            "name": "WordPress",
+            "link": "https://github.com/WordPress/WordPress",
+            "label": "good-for-beginner",
+            "technologies": [
+                "PHP"
+            ],
+            "description": "Wordpress is a free open source tools that lets you build and manage websites without needing to know how to code."
+        },
+        {
             "name": "Laravel Newsletters",
             "link": "https://github.com/spatie/laravel-newsletter",
             "label": "good first issue",


### PR DESCRIPTION
Added a helpful link to WordPress github for beginners under php section.

To improve accessibility for new users, I added a line that links directly to the official WordPress Github resipo. This small addition can help beginners quickly understand what WordPress is and get started more easily.