### PR TITLE
Fix outdated repository links in JavaScript section (#1639)

### DIFF
--- a/data.json
+++ b/data.json
@@ -664,7 +664,7 @@
         },
         {
             "name": "Next.js",
-            "link": "https://github.com/zeit/next.js",
+            "link": "https://github.com/vercel/next.js",
             "label": "good first issue",
             "technologies": [
                 "JavaScript"
@@ -808,7 +808,7 @@
         },
         {
             "name": "material-ui",
-            "link": "https://github.com/mui-org/material-ui",
+            "link": "https://github.com/mui/material-ui",
             "label": "good first issue",
             "technologies": [
                 "JavaScript"
@@ -916,7 +916,7 @@
         },
         {
             "name": "reactjs.org",
-            "link": "https://github.com/reactjs/reactjs.org",
+            "link": "https://github.com/reactjs/react.dev",
             "label": "good first issue",
             "technologies": [
                 "JavaScript"
@@ -979,7 +979,7 @@
         },
         {
             "name": "Vue Router",
-            "link": "https://github.com/vuejs/vue-router",
+            "link": "https://github.com/vuejs/router",
             "label": "good first issue",
             "technologies": [
                 "JavaScript"


### PR DESCRIPTION
This pull request addresses Issue #1639 by updating outdated repository references in the JavaScript section of `data.json`. The following changes were made for accuracy and consistency:

- Updated `reactjs.org` ➜ `react.dev`
- Updated `zeit/next.js` ➜ `vercel/next.js`
- Updated `mui-org/material-ui` ➜ `mui/material-ui`
- Updated `vue-router` ➜ `vuejs/router`

These updates help ensure that contributors are directed to the correct and actively maintained repositories. Let me know if anything needs adjustment. Thanks!
