### PR TITLE
adiciona o repositório fantasy-calendar a lista de repositórios

### DIFF
--- a/data.json
+++ b/data.json
@@ -2200,6 +2200,13 @@
             "label": "good first issue",
             "technologies": ["TypeScript"],
             "description": "The open source Firebase alternative. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications."
+        },
+    {
+            "name": "Fantasy-Calendar",
+            "link": "https://github.com/fantasycalendar/Fantasy-Calendar.git",
+            "label": "good first issue",
+            "technologies": ["PHP"],
+            "description": "Build a calendar that fits your world! Whether you're a GM just here to track your Forgotten Realms campaign with a preset calendar, or a fanciful world-builder with 12 moons (Like Eberron's) and zany timekeeping systems to match, we've got you covered."
         }
     ]
 }


### PR DESCRIPTION
O repositório fantasy-calendar é um projeto para criar calendários para uma mesa de rpg, eu adicionei ele para um projeto open source para iniciantes como uma primeira tentativa.