### PR TITLE
Add BeeWare Briefcase to Python projects

### DIFF
--- a/data.json
+++ b/data.json
@@ -1483,6 +1483,15 @@
             "description": "Open-source RAG assistant that helps users get reliable answers from knowledge sources while avoiding hallucinations."
         },
         {
+            "name": "BeeWare Briefcase",
+            "link": "https://github.com/beeware/briefcase",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "Turn Python projects into distributable native applications across desktop and mobile platforms."
+        },
+        {
             "name": "Bokeh",
             "link": "https://github.com/bokeh/bokeh",
             "label": "good first issue",


### PR DESCRIPTION
## Summary
- add BeeWare Briefcase to the Python beginner-friendly projects list
- highlight its `good first issue` label and cross-platform packaging focus

## Links
- good first issue label: https://github.com/beeware/briefcase/issues?q=is%3Aopen+label%3A%22good+first+issue%22
- contributor guide (optional): https://beeware.org/contributing/first-time/what/