### PR TITLE
Remove dead project links (RawCMS, grok.net)

### DIFF
--- a/data.json
+++ b/data.json
@@ -22,24 +22,6 @@
             "description": "The .NET MVVM framework for cross-platform solutions, including Xamarin.iOS, Xamarin.Android, Windows and Mac."
         },
         {
-            "name": "RawCMS",
-            "link": "https://github.com/arduosoft/RawCMS",
-            "label": "good first issue",
-            "technologies": [
-                ".NET"
-            ],
-            "description": "RawCMS is a headless CMS written in ASP.NET Core, built for developers that embrace API-first technology."
-        },
-        {
-            "name": "grok.net",
-            "link": "https://github.com/Marusyk/grok.net",
-            "label": "good first issue",
-            "technologies": [
-                "C#"
-            ],
-            "description": "Cross platform .NET grok implementation"
-        },
-        {
             "name": "osu!",
             "link": "https://github.com/ppy/osu",
             "label": "good first issue",


### PR DESCRIPTION
### Summary
This pull request removes two inactive or dead project entries from the `data.json` file to keep the repository clean and up to date.

### Changes Made
- Removed **RawCMS** (.NET) — repository inactive / no longer accessible.
- Removed **grok.net** (C#) — repository link returned 404 (dead link).

### Rationale
Both repositories are no longer maintained or available on GitHub.  
Removing these ensures that new contributors only see active, beginner-friendly projects.

### Checklist
- [x] Verified both projects are inaccessible or archived
- [x] Removed entries from `data.json`
- [x] Confirmed JSON validity (no trailing commas)
- [x] Proofread commit and PR description
