### PR TITLE
Improve the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'data.json'
-      - '.github/tpl.md'
+      - '.github/README-template.j2'
 
 jobs:
   build:


### PR DESCRIPTION
- Set the Build workflow to only commit if the README changes: if the README hasn't changed (e.g. a `data.json` reformat was done), it currently attempts to commit and fails, causing a workflow failure.
- Replaced old template file with new one: this means the workflow will now trigger by changes to this template file.