### PR TITLE
Feat: Add back Gophercises project with corrected URL

### DIFF
--- a/data.json
+++ b/data.json
@@ -337,6 +337,14 @@
             "description": "Common Utilities library for Go"
         },
         {
+            "name": "Gophercises",
+            "link": "https://github.com/joncalhoun/gophercises",
+            "technologies": [
+                "Go"
+            ],
+            "description": "A set of free coding exercises to help you become more familiar with Go."
+        },
+        {
             "name": "TEAMMATES",
             "link": "https://github.com/TEAMMATES/teammates",
             "label": "good first issue",


### PR DESCRIPTION
Closes #1792

#### Description

This pull request resolves issue #1792. The "Gophercises" project, which was previously removed due to a broken link, has been re-added to `data.json` with its new, correct URL.

This ensures that this valuable beginner-friendly resource is once again available to new contributors in the "Go" section.

#### Changes Made

- Verified the new location for the Gophercises repository.
- Added the project entry back into `data.json` with the updated link.

**New Entry:**
```json
{
    "name": "Gophercises",
    "link": "https://github.com/joncalhoun/gophercises",
    "technologies": [
        "Go"
    ],
    "description": "A set of free coding exercises to help you become more familiar with Go."
}