### PR TITLE
Feat: Add GitHub Action to check for broken links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,33 +1,20 @@
-# A descriptive name for your workflow
 name: Check for Broken Links
 
-# This section defines when the workflow will run
 on:
-  # Run this workflow automatically every Sunday at 3 AM UTC
   schedule:
     - cron: '0 3 * * 0'
-  # This allows you to run the workflow manually from the GitHub Actions tab
   workflow_dispatch:
 
-# A workflow is made up of one or more "jobs" that can run in parallel or sequence
 jobs:
-  # We'll define a single job called "check-links"
   check-links:
-    # This job will run on the latest version of Ubuntu provided by GitHub
     runs-on: ubuntu-latest
-
-    # The steps that make up the job
     steps:
-      # Step 1: Check out your repository's code so the action can access it
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      # Step 2: Use a pre-made action to check links. This is much easier than writing our own!
       - name: Check links with Lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          # Tell Lychee to check for links inside the data.json file
           args: --verbose ./data.json
         env:
-          # Use the built-in GitHub token to avoid hitting rate limits when checking GitHub links
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Closes #1786

#### Description

This pull request adds a new GitHub Action workflow to automatically check for broken or outdated links in `data.json`.

#### Key Features:
- Runs on a weekly schedule (every Sunday at 3 AM UTC).
- Can also be triggered manually for testing.
- Uses the `lychee-action` to efficiently scan all URLs in `data.json`.
- The workflow will fail if it finds any broken links, making it easy for maintainers to spot problems.

This helps automate repository maintenance and ensures the quality of the resource list for beginners, as requested in issue #1786.