### PR TITLE
Remove H2O Wave Apps from the data.json for inactivity

### DIFF
--- a/data.json
+++ b/data.json
@@ -1888,15 +1888,6 @@
             "description": "Realtime Web Apps and Dashboards framework for Python and R. Suited (not only) for AI audience."
         },
         {
-            "name": "H2O Wave Apps",
-            "link": "https://github.com/h2oai/wave-apps",
-            "label": "hacktoberfest",
-            "technologies": [
-                "Python"
-            ],
-            "description": "Sample AI Apps built with H2O Wave."
-        },
-        {
             "name": "OpenMetadata",
             "link": "https://github.com/open-metadata/OpenMetadata",
             "label": "good first issue",


### PR DESCRIPTION
The last commit was a year ago