### PR TITLE
docs: add Gobyexample under Go category

### DIFF
--- a/data.json
+++ b/data.json
@@ -1044,6 +1044,15 @@
             "description": "Collaborative cheatsheets for console commands."
         },
         {
+    "name": "Gobyexample",
+    "link": "https://gobyexample.com/",
+    "technologies": [
+        "Go"
+    ],
+    "description": "Hands-on introduction to Go using annotated example programs."
+        },
+
+        {
             "name": "The Odin Project Curriculum",
             "link": "https://github.com/TheOdinProject/curriculum",
             "label": "See Description",


### PR DESCRIPTION
Closes: #1792

### What I changed
- Added **Gobyexample** resource under the **Go** category in `data.json`.

### Why this change?
The original Gobyexample entry was missing, and this resource is widely recommended for beginners to learn Go using short annotated examples.

### How I tested
- Verified valid JSON formatting.
- Confirmed correct link formatting.

Checklist:
- [x] I followed CONTRIBUTING.md
- [x] Only data/documentation updated
