### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: install jinja2
         run: sudo pip install jinja2
       - name: Build

--- a/.github/workflows/invalid.yml
+++ b/.github/workflows/invalid.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
            script: |
             await github.rest.issues.createComment({


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/build.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/invalid.yml`
