### PR TITLE
Add HTML to H section in README

### DIFF
--- a/data.json
+++ b/data.json
@@ -1897,6 +1897,7 @@
             "label": "good first issue",
             "technologies": [
                 "Haskell",
+                "HTML",
                 "TypeScript"
             ],
             "description": "Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access control, also trigger webhooks on database events."


### PR DESCRIPTION
This PR adds HTML under the H section in the README for completeness and better discoverability of beginner-friendly technologies.