### PR TITLE
Fix broken Go project link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [Mattermost](https://github.com/mattermost/mattermost) _(label: Good First Issue, Difficulty/1:Easy)_ <br> Open source Slack-alternative in Golang and React<br>Look for issues labelled 'Up For Grabs'
 - [Meshery](https://github.com/layer5io/meshery) _(label: good first issue)_ <br> Meshery, the service mesh management plane.
 - [Moby](https://github.com/moby/moby) _(label: exp/beginner)_ <br> Open-source application container engine
-- [PureLB](https://gitlab.com/purelb/purelb) _(label: n/a)_ <br> Load-balancer orchestrator for Kubernetes that uses standard Linux networking and routing protocols.
+- [PureLB](https://github.com/purelb/purelb) _(label: n/a)_ <br> Load-balancer orchestrator for Kubernetes that uses standard Linux networking and routing protocols.
 - [script](https://github.com/bitfield/script) _(label: good first issue)_ <br> A Go library for doing the kind of tasks that shell scripts are good at: reading files, executing subprocesses, counting lines, matching strings, and so on. Beginners are very welcome and will get detailed code review and help through the PR process.
 - [Terraform](https://github.com/hashicorp/terraform) _(label: good first issue)_ <br> A tool for building, changing, and versioning infrastructure safely and efficiently.
 - [TiDB](https://github.com/pingcap/tidb) _(label: good first issue)_ <br> A distributed scalable Hybrid Transactional and Analytical Processing (HTAP) database


### PR DESCRIPTION
_This PR fixes a broken project link in the Go section of README.md in the awesome-for-beginners repository. The previous link was returning a 404 / invalid page, which could confuse new contributors looking for beginner-friendly Go projects._

**Changes Made**

- Verified the broken link in the Go section.
- Updated the link to the correct working URL.

**Why This Change Is Needed**

- Prevents users from landing on dead or invalid pages.
- Improves the accuracy and reliability of the repository.
- Helps beginners quickly find valid open-source projects to contribute to.

**Testing**

- Opened the updated link in a browser to confirm it loads correctly.
- Verified the README renders properly after the change.