### PR TITLE
fix: correct broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   </div>
 </div>
 
+
 # Awesome First Pull Request Opportunities [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 Inspired by [First Timers Only](https://kentcdodds.com/blog/first-timers-only) blog post.


### PR DESCRIPTION
Link the issue by writing: Fixes #1885

Briefly describe the change: "Corrected a broken link in the README to point to the proper resource."