### PR TITLE
Fix typo: Intitial  Initial in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ It outlines the recommended order for executing tasks and assumes that you have 
 
 _Please note that the list in this repository is intended for more substantial projects, and we kindly ask that small personal projects not be added in the hope of receiving contributions. Thank you for your understanding._
 
-## Intitial Checks
+## Initial Checks
 
 - **Search for Duplicates**: Check the current list and previous pull requests to avoid submitting duplicates.
 


### PR DESCRIPTION
## What
Fixes a typo in CONTRIBUTING.md: "Intitial Checks" → "Initial Checks".

## Why
The heading was misspelled, and this corrects it for better readability.

## Type of change
- [x] Documentation fix (typo)