### PR TITLE
Add PCRE4J to Java section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [elasticsearch](https://github.com/elastic/elasticsearch) _(label: good first issue)_ <br> Open Source, Distributed, RESTful Search Engine.
 - [JabRef](https://github.com/JabRef/jabref) _(label: good first issue)_ <br> Desktop application for managing literature references using modern Java features including JavaFX. Dedicated to code quality and constructive feedback: Each Pull Request is reviewed by two developers to provide high-quality feedback and to ensure high quality of new contributions.
 - [OpenMetadata](https://github.com/open-metadata/OpenMetadata) _(label: good first issue)_ <br> OpenMetadata is an all-in-one platform for data discovery, data quality, observability, governance, data lineage, and team collaboration.
+- [PCRE4J](https://github.com/alexey-pelykh/pcre4j) _(label: good first issue)_ <br> Java binding for the PCRE2 library with java.util.regex-compatible API, wrapper API, and direct PCRE2 API access via JNA and FFM backends.
 - [QuestDB](https://github.com/questdb/questdb) _(label: Good first issue)_ <br> Questdb is a fast open source SQL time series database.
 - [TEAMMATES](https://github.com/TEAMMATES/teammates) _(label: good first issue)_ <br> TEAMMATES is a free online tool for managing peer evaluations and other feedback paths of your students.
 - [Trino (formerly Presto SQL)](https://github.com/trinodb/trino) _(label: good first issue)_ <br> A distributed SQL query engine for big data. Ask for guidance on project's Slack.


### PR DESCRIPTION
Adding [PCRE4J](https://github.com/alexey-pelykh/pcre4j) to the Java section.

PCRE4J is a Java binding for the PCRE2 library providing a `java.util.regex`-compatible API, a wrapper API, and direct PCRE2 API access via JNA and FFM backends. It has several `good first issue` labeled issues for new contributors.