### PR TITLE
Fix: Remove duplicate project listings from data.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ If you would like to be guided through how to contribute to a repository on GitH
 
 - [altair](https://github.com/imolorhe/altair) _(label: good first issue)_ <br> A beautiful feature-rich GraphQL Client for all platforms.
 - [Ancient Beast](https://github.com/FreezingMoon/AncientBeast) _(label: easy)_ <br> Turn based strategy game where you 3d print a squad of creatures with unique abilities in order to defeat your enemies.
-- [appsmith](https://github.com/appsmithorg/appsmith) _(label: good first issue)_ <br> Drag & Drop internal tool builder
 - [AVA](https://github.com/sindresorhus/ava) _(label: good-for-beginner)_ <br> Futuristic test runner.
 - [Babel](https://github.com/babel/babel) _(label: good first issue)_ <br> A compiler for writing next generation JavaScript.
 - [Berry - Active development trunk for Yarn](https://github.com/yarnpkg/berry) _(label: good first issue)_ <br> Fast, reliable, and secure dependency management.

--- a/data.json
+++ b/data.json
@@ -924,15 +924,6 @@
             "description": "A blazing fast unit test framework powered by Vite."
         },
         {
-            "name": "appsmith",
-            "link": "https://github.com/appsmithorg/appsmith",
-            "label": "good first issue",
-            "technologies": [
-                "JavaScript"
-            ],
-            "description": "Drag & Drop internal tool builder"
-        },
-        {
             "name": "Jasmine",
             "link": "https://github.com/jasmine/jasmine",
             "label": "good first issue",

--- a/fix_duplicates.py
+++ b/fix_duplicates.py
@@ -1,0 +1,44 @@
+import json
+
+# Define file paths
+DATA_FILE = 'data.json'
+
+def remove_duplicates():
+    print(f"Loading {DATA_FILE}...")
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    original_count = len(data['repositories'])
+    unique_repos = []
+    seen_links = set()
+    duplicates_found = 0
+
+    # Iterate through repositories and keep only uniques
+    for repo in data['repositories']:
+        # Normalize link to lowercase and strip whitespace for comparison
+        link = repo.get('link', '').strip().lower()
+        
+        if link in seen_links:
+            print(f"Duplicate removed: {repo['name']} ({link})")
+            duplicates_found += 1
+        else:
+            seen_links.add(link)
+            unique_repos.append(repo)
+
+    # Update the data object
+    data['repositories'] = unique_repos
+
+    # Save back to file
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        # Use indent=4 to match the file's existing style
+        json.dump(data, f, indent=4, ensure_ascii=False)
+        # Add a trailing newline which is standard for git files
+        f.write('\n') 
+
+    print("-" * 30)
+    print(f"Total repos before: {original_count}")
+    print(f"Total repos after:  {len(unique_repos)}")
+    print(f"Duplicates removed: {duplicates_found}")
+
+if __name__ == "__main__":
+    remove_duplicates()


### PR DESCRIPTION
I wrote a script to parse data.json and identified duplicate repository URLs. This PR removes those duplicates and regenerates the README to ensure the list is clean and maintainable.