### PR TITLE
Add RustChain to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [Pytest](https://github.com/pytest-dev/pytest) _(label: status:-easy)_ <br> The pytest framework makes it easy to write small tests, yet scales to support complex functional testing.
 - [Python Babel](https://github.com/python-babel/babel) _(label: difficulty/low)_ <br> The Python Internationalization Library.
 - [Pytorch](https://github.com/pytorch/pytorch) _(label: good first issue)_ <br> PyTorch is an open source machine learning library based on the Torch library, used for applications such as computer vision and natural language processing.
+- [RustChain](https://github.com/Scottcjn/Rustchain/labels/good%20first%20issue) _(label: good first issue)_ <br> Proof-of-Antiquity blockchain with hardware attestation that rewards vintage hardware miners (PowerPC, POWER8) with RTC tokens.
 - [SaltStack](https://github.com/saltstack/salt) _(label: good first issue)_ <br> Software to automate the management and configuration of any infrastructure or application at scale.
 - [scikit-learn](https://github.com/scikit-learn/scikit-learn) _(label: good first issue)_ <br> Scikit-learn is a machine learning library for Python.
 - [scrapy](https://github.com/scrapy/scrapy) _(label: good first issue)_ <br> A fast high-level web crawling & scraping framework for Python.


### PR DESCRIPTION
## Add RustChain to Python section

[RustChain](https://github.com/Scottcjn/Rustchain) is a Proof-of-Antiquity blockchain with hardware attestation that rewards vintage hardware miners (PowerPC G4/G5, POWER8) with RTC tokens.

- **Label used**: `good first issue`
- **Active issues**: 49 open good-first-issue labeled issues
- **Actively maintained**: Yes, daily commits
- **Clear contribution guidelines**: Yes
- **Supportive community**: Active Discord + bounty program for contributors