### PR TITLE
Changed electron label from good first issue to beginner friendly

### DIFF
--- a/data.json
+++ b/data.json
@@ -60,7 +60,7 @@
         {
             "name": "electron",
             "link": "https://github.com/electron/electron",
-            "label": "good first issue",
+            "label": "beginner friendly",
             "technologies": [
                 "C++",
                 "JavaScript"


### PR DESCRIPTION
Electron seems to have changed label "good first  issue" to "beginner friendly"

<img width="2358" height="860" alt="beginner-friendly" src="https://github.com/user-attachments/assets/e895846a-4b07-4ba9-b5da-8f8295c75da8" />

<img width="2349" height="837" alt="good-first-issue" src="https://github.com/user-attachments/assets/1e44a373-936d-4237-aaf1-47bd087674f4" />
