### PR TITLE
Fix casing for TypeScript and JavaScript in data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -404,8 +404,8 @@
             "link": "https://github.com/appsmithorg/appsmith",
             "label": "good first issue",
             "technologies": [
-                "Typescript",
-                "Javascript"
+                "TypeScript",
+                "JavaScript"
             ],
             "description": "Drag & Drop internal tool builder"
         },


### PR DESCRIPTION
## Description
This PR corrects a minor capitalization issue in the `data.json` file for the **appsmith** repository entry. 

Previously, the technologies were listed as `"Javascript"` and `"Typescript"`. Because the README is auto-generated from this data, this casing mismatch caused the build script to generate duplicate language headings (`## JavaScript` alongside `## Javascript`, and `## TypeScript` alongside `## Typescript`). This ultimately broke the Table of Contents anchor links for those sections.

Updating them to the standard `"JavaScript"` and `"TypeScript"` will allow the generator to correctly group `appsmith` under the existing headings, fixing the TOC navigation.

## Changes Made
- Updated the `appsmith` technologies array in `data.json`.
  - Changed `"Javascript"` -> `"JavaScript"`
  - Changed `"Typescript"` -> `"TypeScript"`

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] I have made an individual pull request for this specific fix.
- [x] I have verified that no trailing whitespace was added.
- [x] I have proofread my changes for spelling and grammar.