### PR TITLE
Fix casing for TypeScript and JavaScript

### DIFF
--- a/data.json
+++ b/data.json
@@ -404,8 +404,8 @@
             "link": "https://github.com/appsmithorg/appsmith",
             "label": "good first issue",
             "technologies": [
-                "Typescript",
-                "Javascript"
+                "TypeScript",
+                "JavaScript"
             ],
             "description": "Drag & Drop internal tool builder"
         },


### PR DESCRIPTION
Corrected casing for 'TypeScript' and 'JavaScript' in technologies array.