### PR TITLE
Fix: duplicate entry for JavaScript and TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ If you would like to be guided through how to contribute to a repository on GitH
 |E|[Elixir](#elixir), [Elm](#elm)|
 |G|[Go](#go)|
 |H|[Haskell](#haskell)|
-|J|[Java](#java), [JavaScript](#javascript), [Javascript](#javascript), [JSON](#json), [Julia](#julia)|
+|J|[Java](#java), [JavaScript](#javascript), [JSON](#json), [Julia](#julia)|
 |K|[Kotlin](#kotlin)|
 |M|[Markdown](#markdown), [MLOps](#mlops)|
 |P|[Perl](#perl), [PHP](#php), [Pug](#pug), [Python](#python)|
 |R|[Ruby](#ruby), [Rust](#rust)|
 |S|[Scala](#scala), [Smalltalk](#smalltalk), [Swift](#swift)|
-|T|[TypeScript](#typescript), [Typescript](#typescript)|
+|T|[TypeScript](#typescript)|
 
 ## .NET
 


### PR DESCRIPTION
Javascript and typescript were duplicated on the table of contents.