### PR TITLE
Add Weekly Issue Arena (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,6 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [scrapy](https://github.com/scrapy/scrapy) _(label: good first issue)_ <br> A fast high-level web crawling & scraping framework for Python.
 - [SuperDuperDB](https://github.com/SuperDuperDB/superduperdb) _(label: good first issue)_ <br> 🔮SuperDuperDB: Bring AI to your favourite database! Integrate, train and manage any AI models and APIs directly with your database and your data
 - [SymPy](https://github.com/sympy/sympy) _(label: Easy-to-Fix)_ <br> A Python library for symbolic mathematics.
-- [Weekly Issue Arena](https://github.com/claudiotancredi/weekly-issue-arena) _(label: good first issue)_ <br> A weekly-refreshed, gamified hub of open-source issues with an automated contributor leaderboard.
 - [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) _(label: level:starter)_ <br> The strictest and most opinionated python linter ever!
 - [Zulip](https://github.com/zulip/zulip) _(label: good first issue)_ <br> Powerful open source group chat.
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [scrapy](https://github.com/scrapy/scrapy) _(label: good first issue)_ <br> A fast high-level web crawling & scraping framework for Python.
 - [SuperDuperDB](https://github.com/SuperDuperDB/superduperdb) _(label: good first issue)_ <br> 🔮SuperDuperDB: Bring AI to your favourite database! Integrate, train and manage any AI models and APIs directly with your database and your data
 - [SymPy](https://github.com/sympy/sympy) _(label: Easy-to-Fix)_ <br> A Python library for symbolic mathematics.
+- [Weekly Issue Arena](https://github.com/claudiotancredi/weekly-issue-arena) _(label: good first issue)_ <br> A weekly-refreshed, gamified hub of open-source issues with an automated contributor leaderboard.
 - [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) _(label: level:starter)_ <br> The strictest and most opinionated python linter ever!
 - [Zulip](https://github.com/zulip/zulip) _(label: good first issue)_ <br> Powerful open source group chat.
 

--- a/data.json
+++ b/data.json
@@ -1377,6 +1377,15 @@
             "description": "The webservice for gpodder.net, a libre web service that allows users to manage their podcast subscriptions and discover new content."
         },
         {
+            "name": "Weekly Issue Arena",
+            "link": "https://github.com/claudiotancredi/weekly-issue-arena",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "A weekly-refreshed, gamified hub of open-source issues with an automated contributor leaderboard."
+        },
+        {
             "name": "mypy",
             "link": "https://github.com/python/mypy",
             "label": "good first issue",


### PR DESCRIPTION
Adds Weekly Issue Arena to the Python section.

- **Repo**: https://github.com/claudiotancredi/weekly-issue-arena
- **Label**: `good first issue`
- **Active maintenance**: automated workflows run weekly + hourly
- **Supportive community**: GitHub Discussions enabled, users can propose repos