### PR TITLE
Add github-markdown-toc project

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [Terraform](https://github.com/hashicorp/terraform) _(label: good first issue)_ <br> A tool for building, changing, and versioning infrastructure safely and efficiently.
 - [TiDB](https://github.com/pingcap/tidb) _(label: good first issue)_ <br> A distributed scalable Hybrid Transactional and Analytical Processing (HTAP) database
 - [utils](https://github.com/kashifkhan0771/utils) _(label: good first issue)_ <br> Common Utilities library for Go
+- [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc) _(label: good first issue)_ <br> A tool to generate TOC for GitHub README.md files.
 
 ## Haskell
 
@@ -312,7 +313,6 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [SymPy](https://github.com/sympy/sympy) _(label: Easy-to-Fix)_ <br> A Python library for symbolic mathematics.
 - [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) _(label: level:starter)_ <br> The strictest and most opinionated python linter ever!
 - [Zulip](https://github.com/zulip/zulip) _(label: good first issue)_ <br> Powerful open source group chat.
-- [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc) _(label: good first issue)_ <br> A tool to generate TOC (Table of Contents) for GitHub README.md files.
 
 ## Ruby
 


### PR DESCRIPTION
Add github-markdown-toc to the list of good first issues. This is a tool to generate TOC for GitHub README.md files, which is beginner-friendly.