### PR TITLE
docs: explain why repos appear in multiple sections

### DIFF
--- a/.github/README-template.j2
+++ b/.github/README-template.j2
@@ -21,6 +21,10 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 
 If you would like to be guided through how to contribute to a repository on GitHub, check out [the First Contributions repository](https://github.com/firstcontributions/first-contributions).
 
+> [!NOTE]
+> Some repositories appear in multiple sections because they use multiple technologies.
+> This is intentional so beginners can discover projects from the section they are browsing.
+
 > [!TIP]
 > All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
 ## Table of Contents:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If you are not a programmer but would like to contribute, check out the [Awesome
 
 If you would like to be guided through how to contribute to a repository on GitHub, check out [the First Contributions repository](https://github.com/firstcontributions/first-contributions).
 
+> [!NOTE]
+> Some repositories appear in multiple sections because they use multiple technologies.
+> This is intentional so beginners can discover projects from the section they are browsing.
+
 > [!TIP]
 > All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
 ## Table of Contents:


### PR DESCRIPTION
This PR adds a short note in the README template (and generated README) to explain that some repositories intentionally appear in multiple sections because they use multiple technologies. This reduces confusion for beginners while keeping the current discovery flow.