### PR TITLE
Add Appwrite as a beginner-friendly repository

### DIFF
--- a/data.json
+++ b/data.json
@@ -2092,6 +2092,16 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
+        },
+        {
+            "name": "appwrite",
+            "link": "https://github.com/appwrite/appwrite",
+            "label": "good first issue",
+            "technologies": [
+                "TypeScript",
+                "Docker"
+            ],
+            "description": "Appwrite is an open-source backend server that simplifies web and mobile app development with authentication, databases, and storage."
         }
     ]
 }


### PR DESCRIPTION
### Add Appwrite to the list

This PR adds **Appwrite**, an open-source backend platform, to the list of beginner-friendly repositories.

### Why this repo?

* Actively maintained and widely used
* Contains multiple "good first issue" labeled tasks
* Beginner-friendly with good documentation
* Supportive community

Let me know if any changes are required!
