### PR TITLE
Add 'trustcheck' project to data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -2093,5 +2093,17 @@
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
         }
+
+        {
+            "name": "trustcheck",
+            "link": "https://github.com/Halfblood-Prince/trustcheck",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "a Python CLI and library that evaluates PyPI package trust using metadata, vulnerabilities, provenance, publisher signals, and repo consistency, with support for dependency scans and CI-friendly output."
+"
+        }
+        
     ]
 }


### PR DESCRIPTION
Added a new project entry for 'trustcheck' with details.

TrustCheck is a Python CLI and library for evaluating the trust posture of PyPI packages before installation or deployment. It analyzes package metadata, vulnerability records, provenance attestations, Trusted Publisher signals, and repository consistency to produce a clear trust report. It supports single-package inspection, dependency tree analysis, and CI-friendly scanning of requirements.txt or pyproject.toml files, with both human-readable and JSON output for automation.