### PR TITLE
Add ci-doctor under JavaScript projects (6 good-first-issues open)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [Vue.js](https://github.com/vuejs/vue) _(label: good first issue)_ <br> The Progressive JavaScript Framework.
 - [VuePress](https://github.com/vuejs/vuepress) _(label: good first issue)_ <br> Minimalistic Vue-powered static site generator
 - [webdriver.io](https://github.com/webdriverio/webdriverio) _(label: first-timers-only)_ <br> Next-gen browser and mobile automation test framework for Node.js
+* [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - A CLI that audits GitHub Actions workflows for cost waste, security gaps, and reliability bugs. 16 rules. Six well-scoped good-first-issue tickets currently open across the family of repos.
 
 ## Javascript
 


### PR DESCRIPTION
### What this adds

> * [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - A CLI that audits GitHub Actions workflows for cost waste, security gaps, and reliability bugs. 16 rules. Six well-scoped good-first-issue tickets currently open across the family of repos.

### Why

ci-doctor is a free MIT-licensed CLI that audits GitHub Actions workflows for cost waste, security gaps, and reliability bugs (16 rules). It is actively maintained, has a sister CLI for every major CI provider (GitLab, Bitbucket, Azure Pipelines, CircleCI), and ships a public leaderboard scanning the top 100 actions/* repos.

Six well-scoped good-first-issue tickets are currently open across the family of repos, with acceptance criteria and time estimates. PRs get same-day review.

### Conformance to the list

- Single-line entry in the requested section
- Verb-first description, trailing period
- Canonical repo URL as the link target

Happy to revise; ping me on this PR. Thanks for maintaining the list.