### PR TITLE
Fix TypeScript and JavaScript capitalization in appsmith entry

### DIFF
--- a/data.json
+++ b/data.json
@@ -404,8 +404,8 @@
             "link": "https://github.com/appsmithorg/appsmith",
             "label": "good first issue",
             "technologies": [
-                "Typescript",
-                "Javascript"
+                "TypeScript",
+                "JavaScript"
             ],
             "description": "Drag & Drop internal tool builder"
         },


### PR DESCRIPTION

<img width="396" height="47" alt="image" src="https://github.com/user-attachments/assets/ae1ba680-5f87-4bbf-b036-f7dde0dd449f" />

I noticed typos in the `appsmith` data which made it so there were two TypeScript and JavaScript sections. I updated that to match the standard capitalization. Based on the contributions guides it looks like y'all mainly want the edits to the `data.json`, so I left the README untouched. 