### PR TITLE
Add Claude Coach Kit to projects list

### DIFF
--- a/data.json
+++ b/data.json
@@ -2092,6 +2092,17 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
-        }
+        },
+        {
+            "name": "Claude Coach Kit",
+            "link": "https://github.com/krishna-build/claude-coach-kit",
+            "label": "good first issue",
+            "technologies": [
+                "TypeScript",
+                "React",
+                "Supabase"
+            ],
+            "description": "Open-source marketing automation toolkit. Has good-first-issue labels for beginners."
+        },
     ]
 }


### PR DESCRIPTION
Adds Claude Coach Kit, an open-source marketing automation toolkit with good-first-issue labels for beginners.

Project URL: https://github.com/krishna-build/claude-coach-kit
Tech Stack: TypeScript, React, Supabase