### PR TITLE
Remove archived beginner project entries

### DIFF
--- a/data.json
+++ b/data.json
@@ -1737,15 +1737,6 @@
             "description": "Reatom is declarative and reactive state manager, designed for both simple and complex applications."
         },
         {
-            "name": "Graphback",
-            "link": "https://github.com/aerogear/graphback",
-            "label": "good first issue",
-            "technologies": [
-                "TypeScript"
-            ],
-            "description": "A CLI and runtime framework to generate a GraphQL API in seconds."
-        },
-        {
             "name": "LitmusChaos",
             "link": "https://github.com/litmuschaos/litmus",
             "label": "good first issue",
@@ -1875,15 +1866,6 @@
                 ".NET"
             ],
             "description": "A framework for speeding up the development of automated UI tests for Windows, Android, iOS, and Web with Appium/Selenium on .NET."
-        },
-        {
-            "name": "Legerity for Uno Platform",
-            "link": "https://github.com/MADE-Apps/legerity-uno",
-            "label": "good first issue",
-            "technologies": [
-                ".NET"
-            ],
-            "description": "An extension framework to Legerity for speeding up the development of automated UI tests for Uno Platform applications with Appium/Selenium on .NET."
         },
         {
             "name": "OMRChecker",


### PR DESCRIPTION
## Summary
- Remove Graphback and Legerity for Uno Platform from data.json.

## Why
Both linked repositories are archived, while the contribution guide asks entries to be actively maintained.

## Validation
- Confirmed erogear/graphback and MADE-Apps/legerity-uno are archived via the GitHub API.
- Parsed data.json with PowerShell ConvertFrom-Json.
- Left README.md unchanged because it is generated from data.json.