### PR TITLE
Fix appsmith technology casing (Typescript/Javascript -> TypeScript/JavaScript)

### DIFF
--- a/data.json
+++ b/data.json
@@ -404,8 +404,8 @@
             "link": "https://github.com/appsmithorg/appsmith",
             "label": "good first issue",
             "technologies": [
-                "Typescript",
-                "Javascript"
+                "TypeScript",
+                "JavaScript"
             ],
             "description": "Drag & Drop internal tool builder"
         },


### PR DESCRIPTION
My previous PR was (correctly) auto-closed for editing the generated `README.md` directly — this one edits `data.json` instead.

**Problem:** the `appsmith` entry is the only one in `data.json` that lists its technologies as `"Typescript"` and `"Javascript"`. Every other entry uses `"TypeScript"` (29x) and `"JavaScript"` (65x). Since the generator emits one heading per distinct technology string, these mis-cased values create stray duplicate `## Javascript` and `## Typescript` sections in the README. GitHub then gives those second same-name headings a `-1` anchor suffix, so the table-of-contents links `[Javascript](#javascript)` / `[Typescript](#typescript)` point at the wrong (first) sections.

**Fix:** correct appsmith's technologies to `"TypeScript"` and `"JavaScript"`. After the README is regenerated, appsmith lands in the existing canonical sections and the stray sections / duplicate TOC anchors disappear. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)