### PR TITLE
fix: standardize technology casing for appsmith

### DIFF
--- a/data.json
+++ b/data.json
@@ -404,8 +404,8 @@
             "link": "https://github.com/appsmithorg/appsmith",
             "label": "good first issue",
             "technologies": [
-                "Typescript",
-                "Javascript"
+                "TypeScript",
+                "JavaScript"
             ],
             "description": "Drag & Drop internal tool builder"
         },


### PR DESCRIPTION
## Summary

Fixes inconsistent technology name casing for the appsmith entry.

### Changes

* Typescript → TypeScript
* Javascript → JavaScript

This keeps technology names consistent with other repository entries.
