### PR TITLE
clarify why projects may appear in multiple sections

### DIFF
--- a/.github/README-template.j2
+++ b/.github/README-template.j2
@@ -23,6 +23,8 @@ If you would like to be guided through how to contribute to a repository on GitH
 
 > [!TIP]
 > All links open in the same tab. If you want to open in a new tab, use `Ctrl + Click` (Windows/Linux) or `Cmd + Click` (Mac).
+> [!NOTE]
+> Some projects may appear in more than one language or framework section because they use multiple technologies. This does not mean they are different projects; it simply helps beginners discover projects through the language or tool they are most comfortable with.
 ## Table of Contents:
 
 ||Languages|


### PR DESCRIPTION
## What I changed
Added a short note explaining why some projects may appear in multiple language or framework sections.

## Why
Duplicate listings can confuse beginners. This note explains that some projects use multiple technologies, so they may appear in more than one section.

## Related issue
Closes #1900