### PR TITLE
Add tapflow under TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [SigNoz](https://github.com/SigNoz/signoz) _(label: good first issue)_ <br> An Open Source observability platform that monitors your applications and services. It comes with out-of-box charts for key application metrics like p99 latency, error rate, Apdex, and operations per second. You can also monitor the database and external calls made from your application.
 - [Storybook JS](https://github.com/storybookjs/storybook) _(label: good first issue)_ <br> Storybook is a frontend workshop for building UI components and pages in isolation.
 - [supabase](https://github.com/supabase/supabase) _(label: good first issue)_ <br> The open source Firebase alternative. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications.
+- [tapflow](https://github.com/jo-duchan/tapflow) _(label: good first issue)_ <br> Self-hosted mobile QA tool that streams iOS simulators and Android emulators to the browser for team-wide testing without local setup.
 - [tinyhttp](https://github.com/talentlessguy/tinyhttp) _(label: good first issue)_ <br> A 0-legacy, tiny & fast web framework as a replacement of Express.
 - [TypeScript](https://github.com/Microsoft/TypeScript) _(label: good first issue)_ <br> A superset of JavaScript that compiles to clean JavaScript output.
 - [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) _(label: good first issue)_ <br> Monorepo for all the tooling which enables ESLint to support TypeScript.


### PR DESCRIPTION
Adds **tapflow** to the TypeScript section.

tapflow is an open-source, self-hosted tool that streams iOS simulators and Android emulators to the browser, so the whole team (PM, design, QA, engineers) can test mobile apps without Xcode or local device setup.

- Beginner-friendly issues under the `good first issue` label
- Actively maintained, MIT licensed, with README and CONTRIBUTING guides
- Inserted in alphabetical order (between `supabase` and `tinyhttp`), matching the existing entry format

🤖 Generated with [Claude Code](https://claude.com/claude-code)