### PR TITLE
Add tapflow under TypeScript

### DIFF
--- a/data.json
+++ b/data.json
@@ -1764,6 +1764,15 @@
             "description": "A truly serverless framework, write your code and deploy it in seconds without any server configuration files."
         },
         {
+            "name": "tapflow",
+            "link": "https://github.com/jo-duchan/tapflow",
+            "label": "good first issue",
+            "technologies": [
+                "TypeScript"
+            ],
+            "description": "Self-hosted iOS & Android simulator streaming so the whole team can test mobile apps in the browser."
+        },
+        {
             "name": "tinyhttp",
             "link": "https://github.com/talentlessguy/tinyhttp",
             "label": "good first issue",


### PR DESCRIPTION
Adds **tapflow** to the list via `data.json` (README is auto-generated, left untouched).

tapflow is an open-source, self-hosted tool that streams iOS simulators and Android emulators to the browser, so the whole team (PM, design, QA, engineers) can test mobile apps without Xcode or local device setup.

- MIT licensed, actively maintained
- Open issues under the `good first issue` label: https://github.com/jo-duchan/tapflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
- Single addition, edited `data.json` only (no manual README edits)