### PR TITLE
data(feat): add Payload Components to beginner list

### DIFF
--- a/data.json
+++ b/data.json
@@ -446,6 +446,16 @@
             "description": "The easy-to-use OpenStreetMap editor in JavaScript."
         },
         {
+            "name": "Payload Components",
+            "link": "https://github.com/Ducksss/payload-components",
+            "label": "good first issue",
+            "technologies": [
+                "TypeScript",
+                "JavaScript"
+            ],
+            "description": "MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects."
+        },
+        {
             "name": "PouchDB",
             "link": "https://github.com/pouchdb/pouchdb",
             "label": "help-wanted",


### PR DESCRIPTION
## Summary
- Add Payload Components to `data.json`.
- Use the existing `good first issue` label and TypeScript/JavaScript technology tags.

## Project fit
Payload Components is an MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects. The repository now has beginner-labeled issues and a contribution guide.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('data.json','utf8'))"`
- Python assertion that the Payload Components entry exists once with the expected label and technologies
