### PR TITLE
Prevent unsafe HTML from being rendered in generated README content

### DIFF
--- a/.github/README-template.j2
+++ b/.github/README-template.j2
@@ -19,11 +19,11 @@ If you would like to be guided through how to contribute to a repository on GitH
 
 ||Languages|
 |--|--|{% for category_group, categories in category_groups.items() %}
-|{{ category_group }}|{% for category in categories %}[{{ category.title }}](#{{ category.link_id }}){% if loop.index < (categories | length) %}, {% endif %}{% endfor %}|{% endfor %}
+|{{ category_group }}|{% for category in categories %}[{{ category.title | escape_angle_brackets }}](#{{ category.link_id }}){% if loop.index < (categories | length) %}, {% endif %}{% endfor %}|{% endfor %}
 {% for category in categories %}
-## {{ category.title }}
+## {{ category.title | escape_angle_brackets }}
 {% for entry in category.entries %}
-- [{{ entry.name }}]({{ entry.link }}) _(label: {% if entry.label is defined %}{{ entry.label }}{% else %}n/a{% endif %})_ <br> {{ entry.description }}{% endfor %}
+- [{{ entry.name | escape_angle_brackets }}]({{ entry.link }}) _(label: {% if entry.label is defined %}{{ entry.label | escape_angle_brackets }}{% else %}n/a{% endif %})_ <br> {{ entry.description | escape_description }}{% endfor %}
 {% endfor %}
 
 ## Contribute
@@ -32,7 +32,7 @@ Contributions are welcome! See the [contributing guidelines](CONTRIBUTING.md).
 
 ## Thanks to GitHub Sponsors
 
-<table><tr>{% for sponsor in sponsors %}{% if loop.index != 1 and (loop.index - 1) % 6 == 0 %}</tr><tr>{% endif %}<td align="center"><a href="{{ sponsor.link }}"><img src="{{ sponsor.image }}" width="60px;" alt=""/><br/><sub><b>{{ sponsor.name }}</b></sub></a></td>{% endfor %}</tr></table>
+<table><tr>{% for sponsor in sponsors %}{% if loop.index != 1 and (loop.index - 1) % 6 == 0 %}</tr><tr>{% endif %}<td align="center"><a href="{{ sponsor.link }}"><img src="{{ sponsor.image }}" width="60px;" alt=""/><br/><sub><b>{{ sponsor.name | escape_angle_brackets }}</b></sub></a></td>{% endfor %}</tr></table>
 
 ## License
 

--- a/.github/scripts/render-readme.py
+++ b/.github/scripts/render-readme.py
@@ -9,6 +9,19 @@ TARGETFILE = "./README.md"
 def new_technology_dict(repo_technology):
     return {"link_id": repo_technology.lower(), "entries": []}
 
+
+def escape_angle_brackets(text):
+    return str(text).replace("<", "&lt;").replace(">", "&gt;")
+
+
+def escape_description(text):
+    escaped_text = escape_angle_brackets(text)
+    escaped_text = escaped_text.replace("&lt;br&gt;", "<br>")
+    escaped_text = escaped_text.replace("&lt;br/&gt;", "<br/>")
+    escaped_text = escaped_text.replace("&lt;br /&gt;", "<br />")
+    return escaped_text
+
+
 technologies = {}
 
 with open(DATAFILE, "r") as datafile:
@@ -28,6 +41,8 @@ for repository in data["repositories"]:
         technologies[repo_technology]["entries"].append(repository)
 
 env = Environment(loader=FileSystemLoader(TEMPLATEPATH))
+env.filters["escape_angle_brackets"] = escape_angle_brackets
+env.filters["escape_description"] = escape_description
 template = env.get_template(TEMPLATEFILE)
 
 categories = []

--- a/tests/test_render_readme.py
+++ b/tests/test_render_readme.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+from subprocess import run
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "render-readme.py"
+TEMPLATE_PATH = REPO_ROOT / ".github" / "README-template.j2"
+
+
+class RenderReadmeTests(TestCase):
+    def test_generated_readme_escapes_html_but_keeps_br(self):
+        with TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            github_dir = temp_path / ".github"
+            github_dir.mkdir()
+            (github_dir / "README-template.j2").write_text(TEMPLATE_PATH.read_text(), encoding="utf-8")
+
+            data = {
+                "sponsors": [{"name": "Sponsor <b>", "image": "https://example.com/s.png", "link": "https://example.com"}],
+                "technologies": {"Test": "test"},
+                "repositories": [{"name": "Repo <b>", "link": "https://example.com/repo", "label": "good <issue>", "technologies": ["Test"], "description": "Plain text & more<br><script>alert(1)</script>"}],
+            }
+            (temp_path / "data.json").write_text(json.dumps(data), encoding="utf-8")
+
+            result = run(["python", str(SCRIPT_PATH)], cwd=temp_path, check=True, capture_output=True, text=True)
+
+            self.assertEqual(result.returncode, 0)
+            generated = (temp_path / "README.md").read_text(encoding="utf-8")
+            self.assertIn("Repo &lt;b&gt;", generated)
+            self.assertIn("good &lt;issue&gt;", generated)
+            self.assertIn("Plain text & more<br>&lt;script&gt;alert(1)&lt;/script&gt;", generated)
+            self.assertIn("Sponsor &lt;b&gt;", generated)


### PR DESCRIPTION
This change improves the safety of the README generation process by sanitizing repository metadata before it is rendered into the generated output. The update helps prevent unintended HTML content from being rendered while preserving the existing formatting used throughout the project.

To ensure the behavior remains consistent, regression tests were added to verify that potentially unsafe markup is escaped correctly and that normal content continues to render as expected. The change is small, low-maintenance, and does not modify the generated README itself.
