### PR TITLE
Prevent issue counter from hanging on GitHub API requests

### DIFF
--- a/.github/scripts/cghi.py
+++ b/.github/scripts/cghi.py
@@ -1,19 +1,25 @@
 import click
 import requests
 
-def get_open_issues(repo_owner, repo_name, search_params):
-    api_url = f"https://api.github.com/search/issues?q=is:issue%20state:open%20repo:{repo_owner}/{repo_name}"
+DEFAULT_TIMEOUT_SECONDS = 10
+
+
+def get_open_issues(repo_owner, repo_name, search_params, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+    query_parts = ["is:issue", "state:open", f"repo:{repo_owner}/{repo_name}"]
     for search_param, param in search_params:
-        api_url += f'%20{search_param}:"{param}"'
-    print(api_url)
-    response = requests.get(api_url)
-    if response.status_code == 200:
-        data = response.json()
-        # print(data)
-        print(data["total_count"])
-    else:
-        printer(f"HTTP Error: {response.status_code}")
-        exit(1)
+        query_parts.append(f'{search_param}:"{param}"')
+
+    try:
+        response = requests.get(
+            "https://api.github.com/search/issues",
+            params={"q": " ".join(query_parts)},
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise click.ClickException(f"GitHub API request failed: {exc}") from exc
+
+    click.echo(response.json()["total_count"])
 
 @click.command()
 @click.argument("repo_owner")
@@ -29,10 +35,17 @@ def get_open_issues(repo_owner, repo_name, search_params):
     e.g. `-p label "good first issue"`
     '''
 )
-def cghi(repo_owner, repo_name, search_params):
-    """Counts the number of GitHub issues"""
-    print(search_params)
-    get_open_issues(repo_owner, repo_name, search_params)
+@click.option(
+    "--timeout",
+    "timeout_seconds",
+    default=DEFAULT_TIMEOUT_SECONDS,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Seconds to wait for GitHub before failing fast.",
+)
+def cghi(repo_owner, repo_name, search_params, timeout_seconds):
+    """Count open GitHub issues without waiting indefinitely for the API."""
+    get_open_issues(repo_owner, repo_name, search_params, timeout_seconds=timeout_seconds)
 
 if __name__ == "__main__":
     cghi()

--- a/tests/test_issue_counter.py
+++ b/tests/test_issue_counter.py
@@ -1,0 +1,51 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "cghi.py"
+SPEC = importlib.util.spec_from_file_location("cghi", SCRIPT_PATH)
+cghi = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = cghi
+SPEC.loader.exec_module(cghi)
+
+
+class IssueCounterTests(TestCase):
+    def test_get_open_issues_uses_default_timeout_and_reports_count(self):
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"total_count": 7}
+
+        with patch.object(cghi.requests, "get", return_value=response) as mocked_get:
+            with patch.object(cghi.click, "echo") as mocked_echo:
+                cghi.get_open_issues("owner", "repo", [("label", "good first issue")])
+
+        mocked_get.assert_called_once_with(
+            "https://api.github.com/search/issues",
+            params={"q": 'is:issue state:open repo:owner/repo label:"good first issue"'},
+            timeout=cghi.DEFAULT_TIMEOUT_SECONDS,
+        )
+        mocked_echo.assert_called_once_with(7)
+
+    def test_get_open_issues_wraps_request_errors(self):
+        error = cghi.requests.RequestException("boom")
+
+        with patch.object(cghi.requests, "get", side_effect=error):
+            with self.assertRaises(cghi.click.ClickException):
+                cghi.get_open_issues("owner", "repo", [])
+
+    def test_cli_accepts_custom_timeout(self):
+        with patch.object(cghi, "get_open_issues") as mocked_get_open_issues:
+            cghi.cghi.main(
+                ["owner", "repo", "--timeout", "3"],
+                standalone_mode=False,
+            )
+
+        mocked_get_open_issues.assert_called_once_with(
+            "owner",
+            "repo",
+            (),
+            timeout_seconds=3,
+        )


### PR DESCRIPTION
## Description

This change improves the GitHub issue counter by adding a request timeout and handling API failures more gracefully.

Previously, a stalled or unresponsive GitHub API request could cause the command to wait indefinitely. With this update, requests are bounded by a configurable timeout and failures are reported through a clear user-friendly error message instead of hanging or crashing unexpectedly.

The patch also includes tests covering timeout behavior and error handling to help prevent regressions in the future.
