### PR TITLE
Add AI Language Partner

### DIFF
--- a/data.json
+++ b/data.json
@@ -2066,6 +2066,16 @@
             "description": "A modern, fast (high-performance) web framework for building APIs with Python 3.6+ based on standard Python type hints."
         },
         {
+            "name": "AI Language Partner",
+            "link": "https://github.com/duct-tape2/ai-language-partner",
+            "label": "first-timers-only",
+            "technologies": [
+                "TypeScript",
+                "Python"
+            ],
+            "description": "Local-first Japanese speaking practice app for Korean learners with Expo, FastAPI, and local STT/TTS."
+        },
+        {
             "name": "Readest",
             "link": "https://github.com/readest/readest",
             "label": "good first issue",


### PR DESCRIPTION
Adds AI Language Partner as a TypeScript/Python project with beginner-friendly issues.

Project fit:
- Public repo: https://github.com/duct-tape2/ai-language-partner
- Beginner label: `first-timers-only`
- Open beginner issues currently available: 16
- The repository has contributor docs, a first PR walkthrough, issue templates, and a first PR help desk discussion.

Validation:
- `python3 -m json.tool data.json`
- Verified there is exactly one AI Language Partner entry.
- Verified GitHub label `first-timers-only` exists and currently has 16 open issues.
