### PR TITLE
Add django-orm-lens (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ If you would like to be guided through how to contribute to a repository on GitH
 - [datascience](https://github.com/data-8/datascience) _(label: good first issue)_ <br> A Jupyter notebook Python library for introductory data science.
 - [Devopness](https://github.com/devopness/devopness) _(label: good first issue)_ <br> Deploy any software to any cloud: automated DevOps workflows to save software teams time and money.
 - [django cookiecutter](https://github.com/pydanny/cookiecutter-django) _(label: hacktoberfest)_ <br> An implementation of Python for backend web development.
+- [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) _(label: good first issue)_ <br> Static analysis for Django models — VS Code extension + Python CLI + MCP server for AI agents. Zero database, zero Django boot. Beginner-friendly issues cover README translations, small CLI fixes, docs, and golden test fixtures.
 - [DocsGPT](https://github.com/arc53/DocsGPT) _(label: good first issue)_ <br> Open-source RAG assistant that helps users get reliable answers from knowledge sources while avoiding hallucinations.
 - [Fabric](https://github.com/fabric/fabric) _(label: Low-hanging-fruit)_ <br> Pythonic remote execution and deployment.
 - [FastAPI](https://github.com/tiangolo/fastapi) _(label: good first issue)_ <br> A modern, fast (high-performance) web framework for building APIs with Python 3.6+ based on standard Python type hints.


### PR DESCRIPTION
Adds `django-orm-lens` to the Python section (alphabetical position, between `django cookiecutter` and `DocsGPT`).

- Repo: https://github.com/FROWNINGdev/django-orm-lens
- License: MIT
- Language: Python (CLI + MCP server) + TypeScript (VS Code extension)
- Good first issues: https://github.com/FROWNINGdev/django-orm-lens/labels/good%20first%20issue (8 open, all under 1 hour with clear acceptance criteria — README translations, small CLI paper-cuts, docs, and a new golden fixture)

Beginner-friendly because contributions are accepted at all levels (docs, translations, screenshots, one-line typo fixes all count via the all-contributors spec).