### PR TITLE
Add MoonDownloader

### DIFF
--- a/data.json
+++ b/data.json
@@ -2074,10 +2074,8 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
-        }
-    ]
-},
-     {
+        },
+        {
             "name": "MoonDownloader",
             "link": "https://github.com/LeyckerS/moondownloader",
             "label": "good first issue",
@@ -2086,3 +2084,5 @@
             ],
             "description": "Bulk file downloader for datanodes.to and fuckingfast.co: real-Chrome extraction over CDP, pure-HTTP extraction with a Chrome TLS fingerprint, aiohttp streaming, a WebView2 GUI and a headless CLI."
         }
+    ]
+}

--- a/data.json
+++ b/data.json
@@ -2076,4 +2076,13 @@
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
         }
     ]
-}
+},
+     {
+            "name": "MoonDownloader",
+            "link": "https://github.com/LeyckerS/moondownloader",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "Bulk file downloader for datanodes.to and fuckingfast.co: real-Chrome extraction over CDP, pure-HTTP extraction with a Chrome TLS fingerprint, aiohttp streaming, a WebView2 GUI and a headless CLI."
+        }

--- a/data.json
+++ b/data.json
@@ -2082,7 +2082,7 @@
             "technologies": [
                 "Python"
             ],
-            "description": "Bulk file downloader for datanodes.to and fuckingfast.co: real-Chrome extraction over CDP, pure-HTTP extraction with a Chrome TLS fingerprint, aiohttp streaming, a WebView2 GUI and a headless CLI."
+            "description": "Bulk file downloader for Windows: real-Chrome extraction over CDP, pure-HTTP extraction with a Chrome TLS fingerprint, aiohttp streaming, a WebView2 GUI and a headless CLI."
         }
     ]
 }


### PR DESCRIPTION
Adding MoonDownloader, a bulk file downloader written in Python.

- **Repository:** https://github.com/LeyckerS/moondownloader
- **Beginner label:** [`good first issue`](https://github.com/LeyckerS/moondownloader/labels/good%20first%20issue) — the standard GitHub label, currently 8 open issues carrying it
- **Language:** Python 3.10+

Every open issue names the files to touch, lists acceptance criteria, and states whether a Windows machine is needed — most of the work does not need one, because the test suite stubs Chrome and the network so it runs on Linux and macOS. A pinned roadmap issue is the entry point for newcomers, and two external pull requests were reviewed and merged today.

`CONTRIBUTING.md` covers the architecture and the verification commands. Licensed MIT.