### PR TITLE
Add ItsPaint

### DIFF
--- a/data.json
+++ b/data.json
@@ -1701,6 +1701,15 @@
             "description": "A basic app to track your car's maintenance events, like fixes, oil changes, etc."
         },
         {
+            "name": "ItsPaint",
+            "link": "https://github.com/joshlin2201/itspaint",
+            "label": "good first issue",
+            "technologies": [
+                "Swift"
+            ],
+            "description": "A native macOS paint and screenshot markup app. The drawing engine is a UI-free SwiftPM package with its own test suite, so most issues can be solved and tested without touching the app."
+        },
+        {
             "name": "TypeScript",
             "link": "https://github.com/Microsoft/TypeScript",
             "label": "good first issue",


### PR DESCRIPTION
Adds **ItsPaint** — https://github.com/joshlin2201/itspaint

**Label:** `good first issue` — https://github.com/joshlin2201/itspaint/issues?q=is%3Aopen+label%3A%22good+first+issue%22

Against the requirements in CONTRIBUTING.md:

- **Reasonably developed.** A shipping macOS app: signed, notarised, on the Mac App Store, distributed through a Homebrew cask, MIT, 275 passing tests across 40 suites. Not a scaffold.
- **Actively maintained.** 0.12.0 is out; the two bugs filed by users so far were fixed and released. Commits this week.
- **Appropriate labels.** Three issues are open under `good first issue` right now (#3, #4, #5), each with the file and line the work starts at, the shape of the change, and what "done" means. They are real roadmap items, not filler.
- **Supportive community.** CONTRIBUTING.md and a code of conduct are in the repo, and issues get answered same-day.

One thing worth calling out, since the guide asks for judgement here: the list has **one** Swift entry in 227. Part of why is that most Swift projects hand a newcomer an Xcode project and an Apple-platform toolchain before they can run anything. This one does not have to — the drawing engine is a separate UI-free SwiftPM package, so all three of the open issues are solved and tested with `swift test --package-path Packages/PaintKit`, which runs in about four seconds and needs no app, no simulator and no signing.