### PR TITLE
Add YazSes

### DIFF
--- a/data.json
+++ b/data.json
@@ -2074,6 +2074,15 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
+        },
+        {
+            "name": "YazSes",
+            "link": "https://github.com/MSKazemi/yazses",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "Voice dictation and speech-to-text for Linux, macOS and Windows. Hold a key, speak, release, and the text is typed into the focused window. Runs on the CPU with faster-whisper; nothing leaves the machine by default."
         }
     ]
 }


### PR DESCRIPTION
### YazSes — https://github.com/MSKazemi/yazses

Voice dictation and speech-to-text for Linux, macOS and Windows. Hold a key, speak, release, and the text is typed into the focused window. Runs on the CPU with faster-whisper; nothing leaves the machine by default.

**Why it fits this list**

- **20 open [`good first issue`](https://github.com/MSKazemi/yazses/labels/good%20first%20issue) tasks**, and several need no Python at all — writing an example config, documenting a known-good microphone, translating the README, or just running it on your hardware and reporting what happened.
- **Established, not a weekend project**: v2.17, 2728 tests, packaged on PyPI, Snap and APT, with a full docs site, a `CONTRIBUTING.md`, a `GOVERNANCE.md` and a code of conduct.
- **Actively maintained** by nine contributors; the last six community PRs were reviewed and merged, and issues generally get a reply within a few days.
- **Newcomer-friendly by design**: the test suite is fully offline and runs in ~30s — no microphone, no model download and no GPU needed to contribute.

Checked against `CONTRIBUTING.md`: not already listed, direct repository link, one repository in this PR, no trailing whitespace.