### PR TITLE
Add SysKnife (Rust): MCP server for Linux sysadmin, 15 good first issues

### DIFF
--- a/data.json
+++ b/data.json
@@ -1656,6 +1656,15 @@
             "description": "Application to comfortably monitor network traffic."
         },
         {
+            "name": "SysKnife",
+            "link": "https://github.com/lacs-project/sysknife",
+            "label": "good first issue",
+            "technologies": [
+                "Rust"
+            ],
+            "description": "Linux sysadmin co-pilot that turns plain-language requests into typed, risk-classified actions a privileged daemon runs only after terminal approval, with an Ed25519-signed audit chain."
+        },
+        {
             "name": "Twitter Util",
             "link": "https://github.com/twitter/util",
             "label": "good first issue",


### PR DESCRIPTION
Adding SysKnife under Rust.

**What it is.** A Linux sysadmin co-pilot that runs as an MCP server. A
plain-language request becomes a plan of typed, risk-classified actions, and a
privileged daemon runs them only after a human mints a single-use approval receipt
in a terminal. Every authorisation decision joins an Ed25519-signed hash chain
that a third party can verify with only the exported public key.

**Label.** `good first issue`, 15 issues open. The name is the GitHub default, so
it needs no explanation.

**Against the repository requirements.**

- *Reasonably developed*: 84k lines of Rust across five crates, 1,759 tests in the
  workspace baseline, released at v0.8.0 on crates.io and npm. Three Ubuntu LTS
  releases each pass a 79-story end-to-end suite on a live VM, each with a
  committed replay twin that reproduces the run offline.
- *Active maintenance*: commits most days, and the last release landed two days
  ago.
- *Appropriate labels*: difficulty is labelled `easy`, `medium`, `hard` or
  `tedious` on every issue, alongside `good first issue` and `help wanted`. An
  issue somebody has claimed carries a `claimed` label so nobody duplicates work.
- *Supportive community*: two contributors picked up issues yesterday and both had
  a substantive answer the same day, including corrections to my issue text where
  they had found it wrong.

**What a first contribution looks like here.** Issues name the file and line,
quote the code, state what breaks, and propose the test to write first. Three
current examples: a sanitizer that strips invisible characters but skips the two
its neighbouring module treats as line breaks; a 4 MiB frame limit declared once
per side of a protocol with nothing holding the two equal; a shell assertion that
cannot fail because `pipefail` makes the pipeline status the scanner's own exit
code.

No CLA and no copyright waiver, MIT licensed. The suite runs in about ninety
seconds and a local pre-commit hook runs the same gates as CI.

**One thing to weigh openly.** The project is young by stars, at 6. Your guidance
about small personal projects is fair, and I would rather name that than hope you
miss it. If the bar here is audience rather than code, decline this and I will
come back once outside contributions have merged.
