### PR TITLE
Add deja-vu

### DIFF
--- a/data.json
+++ b/data.json
@@ -2074,6 +2074,15 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
+        },
+        {
+            "name": "deja-vu",
+            "link": "https://github.com/vshulcz/deja-vu",
+            "label": "good first issue",
+            "technologies": [
+                "Go"
+            ],
+            "description": "Memory for coding agents, built from the session files they already write to disk: search, recall over MCP, and automatic recall across twenty agents."
         }
     ]
 }


### PR DESCRIPTION
deja-vu indexes the session files Claude Code, Codex, Cursor, opencode and sixteen more coding agents already write to disk, and serves them back through the terminal or over MCP. Go, MIT, no LLM and no embeddings.

On the requirements: it is actively maintained (releases most weeks), thirty-two pull requests from other contributors are merged, and issues are labelled `good first issue` — currently a formatting fix, a bounded counting bug and a documentation page, each with the failing case written out in the issue.