### PR TITLE
Add Plonk

### DIFF
--- a/data.json
+++ b/data.json
@@ -1701,6 +1701,15 @@
             "description": "A basic app to track your car's maintenance events, like fixes, oil changes, etc."
         },
         {
+            "name": "Plonk",
+            "link": "https://github.com/ostapondo/Plonk",
+            "label": "good first issue",
+            "technologies": [
+                "Swift"
+            ],
+            "description": "A window manager for macOS. Draw the zones you want on each monitor, then drop windows into them with a drag, a shortcut or by saying so out loud."
+        },
+        {
             "name": "TypeScript",
             "link": "https://github.com/Microsoft/TypeScript",
             "label": "good first issue",


### PR DESCRIPTION
Adding Plonk, a window manager for macOS written in Swift. You draw the zones you want on each monitor and drop windows into them with a drag, a shortcut or by saying so out loud. MIT, macOS 13 and up, no dependencies.

Label: `good first issue`, https://github.com/ostapondo/Plonk/labels/good%20first%20issue

Seven are open right now. Each one names the files involved and says what a PR needs, and a few need no Xcode at all (a docs page for another MCP client, a layout file). CONTRIBUTING.md covers the build. You do not need a signing certificate or an Apple account to work on it.

I am the only maintainer. Issues get an answer within 48 hours; that is written into CONTRIBUTING.md as a promise. Two people besides me have landed changes so far. If that is too small for this list, say so and I will come back later.
