### PR TITLE
Remove deprecated Create React App entry from data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -943,15 +943,6 @@
             "description": "A UI components library for Elasticsearch: Available for React, Vue and React Native."
         },
         {
-            "name": "Create React App",
-            "link": "https://github.com/facebook/create-react-app",
-            "label": "good first issue",
-            "technologies": [
-                "JavaScript"
-            ],
-            "description": "Create React apps with no build configuration."
-        },
-        {
             "name": "Svelte",
             "link": "https://github.com/sveltejs/svelte",
             "label": "good first issue",


### PR DESCRIPTION
### Description
Removes `facebook/create-react-app` from `data.json`.

### Reason
The React core team officially deprecated Create React App in favor of modern build tools (such as Vite) and frameworks (such as Next.js/Remix). Since it is no longer maintained or recommended for new projects, removing it ensures beginners are not directed toward obsolete project setups as well as ensures the project's 'active maintenance' status is maintained.

### Checklist
- [x] Verified valid JSON syntax in `data.json` (no trailing commas or syntax errors).
- [x] Removed trailing whitespace.
- [x] Single repository change per PR.