### PR TITLE
Add OffPDF

### DIFF
--- a/data.json
+++ b/data.json
@@ -2074,6 +2074,16 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
+        },
+        {
+            "name": "OffPDF",
+            "link": "https://github.com/McanKul/offpdf",
+            "label": "good first issue",
+            "technologies": [
+                "Rust",
+                "TypeScript"
+            ],
+            "description": "An open-source, offline-first desktop toolkit for editing, organizing, converting, compressing, securing, and OCRing PDF files locally."
         }
     ]
 }


### PR DESCRIPTION
Adds OffPDF to the Rust and TypeScript sections through `data.json`.

OffPDF is an open-source, offline-first desktop PDF toolkit with curated `good first issue` tasks. I maintain the project and actively review contributor pull requests.

Validation:
- `python3 -m json.tool data.json`
- README generation with `.github/scripts/render-readme.py`