### PR TITLE
Add no_human (Python)

### DIFF
--- a/data.json
+++ b/data.json
@@ -2074,6 +2074,15 @@
                 "Python"
             ],
             "description": "A simple framework that automates ML/DL workflows by providing prebuilt trainers, templates, logging, configuration management, and much more."
+        },
+        {
+            "name": "no_human",
+            "link": "https://github.com/no-human-ai/no_human",
+            "label": "good first issue",
+            "technologies": [
+                "Python"
+            ],
+            "description": "From ticket to reviewed pull request. no_human proves the code it wrote is correct. You drop a ticket on the board (or point it at Jira or Linear) and it plans, writes the code, and opens a pull request. Before that PR reaches you, the work is checked by a second model that never saw the coder's session and is told to assume the job is not done. You get a pass/fail checklist that cites files and lines, not a score. If the agent deleted or weakened a test, a tamper guard stops the attempt. For bug fixes, the tests offered as proof have to fail on the old code and pass on the new. It's Free and open-source, on your machine."
         }
     ]
 }


### PR DESCRIPTION
Adds no_human under Python.

From ticket to reviewed pull request. no_human proves the code it wrote is correct. You drop a ticket on the board (or point it at Jira or Linear) and it plans, writes the code, and opens a pull request. Before that PR reaches you, the work is checked by a second model that never saw the coder's session and is told to assume the job is not done. You get a pass/fail checklist that cites files and lines, not a score. If the agent deleted or weakened a test, a tamper guard stops the attempt. For bug fixes, the tests offered as proof have to fail on the old code and pass on the new. It's Free and open-source, on your machine.

Checklist against the repository requirements:
- **Reasonably developed / active maintenance:** ~1,100 commits, daily activity, releases on PyPI (`no-human`, currently 0.1.8) plus signed desktop builds.
- **Beginner labels:** standard `good first issue` label, 5 open issues, each scoped with the exact file/line, a repro, and a verification command: https://github.com/no-human-ai/no_human/labels/good%20first%20issue
- **Supportive community:** small but honestly run — GitHub Discussions is active, CONTRIBUTING.md documents a credential-free hermetic dev setup (~2,980 tests run without any API key), and I'm the maintainer, committed to guiding and reviewing newcomer PRs promptly.

One repo, direct link, no trailing whitespace; `data.json` round-trips byte-identically apart from the new entry.